### PR TITLE
work around MutatorMath "warping" sources/instances locations

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -22,6 +22,8 @@ import os
 import shutil
 import tempfile
 from collections import OrderedDict
+from contextlib import contextmanager
+from copy import deepcopy
 from functools import partial, wraps
 
 import ufo2ft
@@ -88,6 +90,44 @@ def _deprecated(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+@contextmanager
+def temporarily_disabling_axis_maps(designspace_path):
+    """Context manager to prevent MutatorMath from warping designspace locations.
+
+    MutatorMath assumes that the masters and instances' locations are in
+    user-space coordinates -- whereas they actually are in internal design-space
+    coordinates, and thus they do not need any 'bending'. To work around this we
+    we create a temporary designspace document without the axis maps, and with the
+    min/default/max triplet mapped "forward" from user-space coordinates (input)
+    to internal designspace coordinates (output).
+
+    Args:
+        designspace_path: A path to a designspace document.
+
+    Yields:
+        A temporary path string to the thus modified designspace document.
+        After the context is exited, it removes the temporary file.
+
+    Related issues:
+        https://github.com/LettError/designSpaceDocument/issues/16
+        https://github.com/fonttools/fonttools/pull/1395
+    """
+    designspace = designspaceLib.DesignSpaceDocument.fromfile(designspace_path)
+    for axis in designspace.axes:
+        axis.minimum = axis.map_forward(axis.minimum)
+        axis.default = axis.map_forward(axis.default)
+        axis.maximum = axis.map_forward(axis.maximum)
+        del axis.map[:]
+
+    fd, temp_designspace_path = tempfile.mkstemp()
+    os.close(fd)
+    try:
+        designspace.write(temp_designspace_path)
+        yield temp_designspace_path
+    finally:
+        os.remove(temp_designspace_path)
 
 
 class FontProject(object):
@@ -762,19 +802,23 @@ class FontProject(object):
                 "attribute"
             )
 
-        # TODO: replace mutatorMath with ufoProcessor?
-        builder = DesignSpaceDocumentReader(
-            designspace.path, ufoVersion=3, roundGeometry=round_instances, verbose=True
-        )
-        logger.info("Interpolating master UFOs from designspace")
-        if include is not None:
-            instances = self._search_instances(designspace, pattern=include)
-            for instance_name in instances:
-                builder.readInstance(("name", instance_name))
-            filenames = set(instances.values())
-        else:
-            builder.readInstances()
-            filenames = None  # will include all instances
+        with temporarily_disabling_axis_maps(designspace.path) as temp_designspace_path:
+            builder = DesignSpaceDocumentReader(
+                temp_designspace_path,
+                ufoVersion=3,
+                roundGeometry=round_instances,
+                verbose=True,
+            )
+            logger.info("Interpolating master UFOs from designspace")
+            if include is not None:
+                instances = self._search_instances(designspace, pattern=include)
+                for instance_name in instances:
+                    builder.readInstance(("name", instance_name))
+                filenames = set(instances.values())
+            else:
+                builder.readInstances()
+                filenames = None  # will include all instances
+
         logger.info("Applying instance data from designspace")
         instance_ufos = apply_instance_data(designspace, include_filenames=filenames)
 

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -23,7 +23,6 @@ import shutil
 import tempfile
 from collections import OrderedDict
 from contextlib import contextmanager
-from copy import deepcopy
 from functools import partial, wraps
 
 import ufo2ft


### PR DESCRIPTION
I just made an unexpected discovery..

It turns out that, when a designspace document defines axes `map` elements... (e.g. these are Noto Sans' axes)

```xml
    <axis tag="wght" name="Weight" minimum="100" maximum="900" default="400">
      <map input="100" output="26"/>
      <map input="200" output="39"/>
      <map input="300" output="58"/>
      <map input="400" output="90"/>
      <map input="500" output="108"/>
      <map input="600" output="128"/>
      <map input="700" output="151"/>
      <map input="800" output="169"/>
      <map input="900" output="190"/>
    </axis>
    <axis tag="wdth" name="Width" minimum="62.500000" maximum="100" default="100">
      <map input="62.500000" output="70"/>
      <map input="75" output="79"/>
      <map input="87.500000" output="89"/>
      <map input="100" output="100"/>
    </axis>
```

... MutatorMath will "bend" the masters and instances location coordinates using the provided mappings.

Now, this is actually wrong -- at least from the point of view of what we've always assumed to be the case in fontTools.varLib when creating variable fonts: which is that the DesignSpace masters/instances locations are specified in what we called _internal_ or _design_-space coordinate system (i.e. just arbirary numbers that are convenient while desigining and only used internally for interpolation); this internal, design coordinates as such are considered to be already "bent" or "mapped".

The main reason these axes mappings were introduced was to map from _user_-space coordinates to internal design-space coordinates, in order to build a non-default (non linear) normalization for the avar table. "User" coordinates are the fvar's axes definitions, which may be restricted to predefined ranges or meanings for registered axes (e.g. "Regular" weight must be 400, "Ultra-Condensed" width 50 % of normal, etc.).

_But_.. MutatorMath seems to assume that the masters and instances' locations are in user-space coordinates instead of internal design coordinates, and uses the mappings to 'bend' the locations, producing sometimes unexpected interpolations.

I noticed this while comparing a (SemiCondensed) instance of NotoSans-VF produced using fontTools.varLib.mutator with a static instance at the same (nominal, user-space) weight/width location interpolated via MutatorMath. In particular, adding map elements to the width axes (the ones above) highlighted this issue, whereas the difference was not apparent when only weight contained similar mappings.

MutatorMath is no longer maintained and we plan to replace that with something built upon fontTools.varLib (@madig is onto that).

In the meantime I just wanted raise this issue, and maybe propose a temporary work-around (a hack really) with this PR.

Basically, I create a temporary designspace document _without_ the axis maps, and with the min/default/max triplet mapped "forward" from user-space coordinates (the "input") to internal designspace coordinates (the "output"), to prevent MutatorMath from distorting the locations.

As @behdad suggested more than a year ago, I agree the only good solution going forward to avoid this confusion is to explicitly add an attribute to DesignSpace location elements to qualify unambiguously whether a location is meant to be mapped or not (I'll open a separate PR in fontTools to propose an update to the DesignSpace spec).  

Related issues:
https://github.com/LettError/designSpaceDocument/issues/16
https://github.com/fonttools/fonttools/pull/1395
https://github.com/googlefonts/glyphsLib/issues/483