### PR TITLE
Instantiator: don't copy actual masters

### DIFF
--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -208,7 +208,7 @@ class Instantiator:
         # Kerning
         kerning_instance = self.kerning_mutator.instance_at(location_normalized)
         if self.round_geometry:
-            kerning_instance = kerning_instance.round()
+            kerning_instance.round()
         kerning_instance.extractKerning(font)
 
         # Info

--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -208,7 +208,7 @@ class Instantiator:
         # Kerning
         kerning_instance = self.kerning_mutator.instance_at(location_normalized)
         if self.round_geometry:
-            kerning_instance.round()
+            kerning_instance = kerning_instance.round()
         kerning_instance.extractKerning(font)
 
         # Info

--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -589,9 +589,12 @@ class Variator:
         there is actual interpolation to be done. This enables us to
         store incompatible bare masters in one Designspace and having
         arbitrary instance data applied to them.
+
+        Note: Since we might return an actual master wrapped in a
+        fontMath shell, the return value must not be modified in-place.
         """
         normalized_location_key = location_to_key(normalized_location)
         if normalized_location_key in self.location_to_master:
-            return copy.deepcopy(self.location_to_master[normalized_location_key])
+            return self.location_to_master[normalized_location_key]
 
         return self.model.interpolateFromMasters(normalized_location, self.masters)


### PR DESCRIPTION
Close https://github.com/googlefonts/fontmake/issues/567.

We only call `.round()` and `extract*()` on instantiated fontMath objects, and fontMath seems to make copies appropriately, so we should not need to `deepcopy` everything.