### PR TITLE
Copy font info attributes from default font to instance selectively

### DIFF
--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -102,6 +102,9 @@ WDTH_VALUE_TO_OS2_WIDTH_CLASS = {
 # - macintoshFONDFamilyID
 # - macintoshFONDName
 # - year
+#
+# This means we implicitly require the `stylename` attribute in the Designspace
+# `<instance>` element.
 UFO_INFO_ATTRIBUTES_TO_COPY_TO_INSTANCES = {
     "copyright",
     "familyName",
@@ -371,9 +374,16 @@ class Instantiator:
         # TODO: multilingual names to replace possibly existing name records.
         if instance.familyName:
             font.info.familyName = instance.familyName
-        # styleName is implicitly required because it is not copied from the default
-        # font.
-        font.info.styleName = instance.styleName
+        if instance.styleName is None:
+            logger.warning(
+                "The given instance or instance at location %s is missing the "
+                "stylename attribute, which is required. Copying over the styleName "
+                "from the default font, which is probably wrong.",
+                location,
+            )
+            font.info.styleName = self.copy_info.styleName
+        else:
+            font.info.styleName = instance.styleName
         if instance.postScriptFontName:
             font.info.postscriptFontName = instance.postScriptFontName
         if instance.styleMapFamilyName:

--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -40,7 +40,6 @@ import attr
 import fontMath
 import fontTools.designspaceLib as designspaceLib
 import fontTools.misc.fixedTools
-import fontTools.ufoLib as ufoLib
 import fontTools.varLib as varLib
 import ufoLib2
 
@@ -74,6 +73,75 @@ WDTH_VALUE_TO_OS2_WIDTH_CLASS = {
     125: 7,
     150: 8,
     200: 9,
+}
+
+# Font info fields that are not interpolated and should be copied from the
+# default font to the instance.
+#
+# fontMath at the time of this writing handles the following attributes:
+# https://github.com/robotools/fontMath/blob/0.5.0/Lib/fontMath/mathInfo.py#L360-L422
+#
+# From the attributes that are left, we skip instance-specific ones on purpose:
+# - guidelines
+# - postscriptFontName
+# - styleMapFamilyName
+# - styleMapStyleName
+# - styleName
+# - openTypeNameCompatibleFullName
+# - openTypeNamePreferredFamilyName
+# - openTypeNamePreferredSubfamilyName
+# - openTypeNameUniqueID
+# - openTypeNameWWSFamilyName
+# - openTypeNameWWSSubfamilyName
+# - openTypeOS2Panose
+# - postscriptFullName
+# - postscriptUniqueID
+# - woffMetadataUniqueID
+#
+# Some, we skip because they are deprecated:
+# - macintoshFONDFamilyID
+# - macintoshFONDName
+# - year
+UFO_INFO_ATTRIBUTES_TO_COPY_TO_INSTANCES = {
+    "copyright",
+    "familyName",
+    "note",
+    "openTypeGaspRangeRecords",
+    "openTypeHeadCreated",
+    "openTypeHeadFlags",
+    "openTypeNameDescription",
+    "openTypeNameDesigner",
+    "openTypeNameDesignerURL",
+    "openTypeNameLicense",
+    "openTypeNameLicenseURL",
+    "openTypeNameManufacturer",
+    "openTypeNameManufacturerURL",
+    "openTypeNameRecords",
+    "openTypeNameSampleText",
+    "openTypeNameVersion",
+    "openTypeOS2CodePageRanges",
+    "openTypeOS2FamilyClass",
+    "openTypeOS2Selection",
+    "openTypeOS2Type",
+    "openTypeOS2UnicodeRanges",
+    "openTypeOS2VendorID",
+    "postscriptDefaultCharacter",
+    "postscriptForceBold",
+    "postscriptIsFixedPitch",
+    "postscriptWindowsCharacterSet",
+    "trademark",
+    "versionMajor",
+    "versionMinor",
+    "woffMajorVersion",
+    "woffMetadataCopyright",
+    "woffMetadataCredits",
+    "woffMetadataDescription",
+    "woffMetadataExtensions",
+    "woffMetadataLicense",
+    "woffMetadataLicensee",
+    "woffMetadataTrademark",
+    "woffMetadataVendor",
+    "woffMinorVersion",
 }
 
 
@@ -292,9 +360,7 @@ class Instantiator:
         info_instance.extractInfo(font.info)
 
         # Copy non-interpolating metadata from the default font.
-        for attribute in ufoLib.fontInfoAttributesVersion3:
-            if hasattr(info_instance, attribute):
-                continue  # Skip interpolated info attributes.
+        for attribute in UFO_INFO_ATTRIBUTES_TO_COPY_TO_INSTANCES:
             if hasattr(self.copy_info, attribute):
                 setattr(
                     font.info,
@@ -305,8 +371,9 @@ class Instantiator:
         # TODO: multilingual names to replace possibly existing name records.
         if instance.familyName:
             font.info.familyName = instance.familyName
-        if instance.styleName:
-            font.info.styleName = instance.styleName
+        # styleName is implicitly required because it is not copied from the default
+        # font.
+        font.info.styleName = instance.styleName
         if instance.postScriptFontName:
             font.info.postscriptFontName = instance.postScriptFontName
         if instance.styleMapFamilyName:

--- a/tests/test_instantiator.py
+++ b/tests/test_instantiator.py
@@ -1,3 +1,5 @@
+import logging
+
 import fontTools.designspaceLib as designspaceLib
 import pytest
 import ufoLib2
@@ -299,7 +301,7 @@ def test_instance_attributes(data_dir):
     assert instance_font.info.styleMapStyleName == "xxx"
 
 
-def test_instance_no_attributes(data_dir):
+def test_instance_no_attributes(data_dir, caplog):
     designspace = designspaceLib.DesignSpaceDocument.fromfile(
         data_dir / "DesignspaceTest" / "DesignspaceTest-bare.designspace"
     )
@@ -307,9 +309,12 @@ def test_instance_no_attributes(data_dir):
         designspace, round_geometry=True
     )
 
-    instance_font = generator.generate_instance(designspace.instances[0])
+    with caplog.at_level(logging.WARNING):
+        instance_font = generator.generate_instance(designspace.instances[0])
+    assert "missing the stylename attribute" in caplog.text
+
     assert instance_font.info.familyName == "MyFont"
-    assert instance_font.info.styleName is None
+    assert instance_font.info.styleName == "Light"
     assert instance_font.info.postscriptFontName is None
     assert instance_font.info.styleMapFamilyName is None
     assert instance_font.info.styleMapStyleName is None

--- a/tests/test_instantiator.py
+++ b/tests/test_instantiator.py
@@ -309,7 +309,7 @@ def test_instance_no_attributes(data_dir):
 
     instance_font = generator.generate_instance(designspace.instances[0])
     assert instance_font.info.familyName == "MyFont"
-    assert instance_font.info.styleName == "Light"
+    assert instance_font.info.styleName is None
     assert instance_font.info.postscriptFontName is None
     assert instance_font.info.styleMapFamilyName is None
     assert instance_font.info.styleMapStyleName is None
@@ -459,10 +459,8 @@ def test_data_independence(data_dir):
 
     assert generator.copy_info.openTypeOS2Panose == [2, 11, 5, 4, 2, 2, 2, 2, 2, 4]
     generator.copy_info.openTypeOS2Panose.append(1000)
-    assert instance_font1.info.openTypeOS2Panose == [2, 11, 5, 4, 2, 2, 2, 2, 2, 4]
-    assert instance_font2.info.openTypeOS2Panose == [2, 11, 5, 4, 2, 2, 2, 2, 2, 4]
-    instance_font1.info.openTypeOS2Panose.append(2000)
-    assert instance_font2.info.openTypeOS2Panose == [2, 11, 5, 4, 2, 2, 2, 2, 2, 4]
+    assert instance_font1.info.openTypeOS2Panose is None
+    assert instance_font2.info.openTypeOS2Panose is None
 
     # copy_feature_text not tested because it is a(n immutable) string
 
@@ -472,3 +470,38 @@ def test_data_independence(data_dir):
     assert not instance_font2.lib["public.skipExportGlyphs"]
     instance_font1.lib["public.skipExportGlyphs"].append("z")
     assert not instance_font2.lib["public.skipExportGlyphs"]
+
+
+def test_skipped_fontinfo_attributes():
+    """Test that we consider all available font info attributes for copying."""
+    import fontTools.ufoLib
+    import fontMath.mathInfo
+
+    SKIPPED_ATTRS = {
+        "guidelines",
+        "macintoshFONDFamilyID",
+        "macintoshFONDName",
+        "openTypeNameCompatibleFullName",
+        "openTypeNamePreferredFamilyName",
+        "openTypeNamePreferredSubfamilyName",
+        "openTypeNameUniqueID",
+        "openTypeNameWWSFamilyName",
+        "openTypeNameWWSSubfamilyName",
+        "openTypeOS2Panose",
+        "postscriptFontName",
+        "postscriptFullName",
+        "postscriptUniqueID",
+        "styleMapFamilyName",
+        "styleMapStyleName",
+        "styleName",
+        "woffMetadataUniqueID",
+        "year",
+    }
+
+    assert (
+        fontTools.ufoLib.fontInfoAttributesVersion3
+        - set(fontMath.mathInfo._infoAttrs.keys())
+        - {"postscriptWeightName"}  # Handled in fontMath specially.
+        - fontmake.instantiator.UFO_INFO_ATTRIBUTES_TO_COPY_TO_INSTANCES
+        == SKIPPED_ATTRS
+    )


### PR DESCRIPTION
Closes #574.

I overlooked that ufoProcessor does the same. Several attributes are actually specific to instances and should not be blindly inherited from the default font.

The ignore list is different from ufoProcessor. We additionally ignore:
- openTypeNameUniqueID
- openTypeNameWWSFamilyName
- openTypeNameWWSSubfamilyName
- openTypeOS2Panose

We copy over:
- familyName
- woffMajorVersion
- woffMetadataCopyright
- woffMetadataCredits
- woffMetadataDescription
- woffMetadataExtensions
- woffMetadataLicense
- woffMetadataLicensee
- woffMetadataTrademark
- woffMetadataVendor
- woffMinorVersion

This implies that the styleName attribute is now implicitly required. Not specifying it in the Designspace means it will not be set in the instance.