### PR TITLE
Copy only non-kerning groups explicitly

### DIFF
--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -160,7 +160,7 @@ class Instantiator:
 
     axis_bounds: AxisBounds  # Design space!
     copy_feature_text: str
-    copy_groups: Mapping[str, List[str]]
+    copy_nonkerning_groups: Mapping[str, List[str]]
     copy_info: ufoLib2.objects.Info
     copy_lib: Mapping[str, Any]
     default_design_location: Location
@@ -228,7 +228,11 @@ class Instantiator:
 
         # Construct defaults to copy over
         copy_feature_text: str = default_font.features.text
-        copy_groups: Mapping[str, List[str]] = default_font.groups
+        copy_nonkerning_groups: Mapping[str, List[str]] = {
+            key: glyph_names
+            for key, glyph_names in default_font.groups.items()
+            if not key.startswith(("public.kern1.", "public.kern2."))
+        }  # Kerning groups are taken care of by the kerning Variator.
         copy_info: ufoLib2.objects.Info = default_font.info
         copy_lib: Mapping[str, Any] = default_font.lib
 
@@ -241,7 +245,7 @@ class Instantiator:
         return cls(
             axis_bounds,
             copy_feature_text,
-            copy_groups,
+            copy_nonkerning_groups,
             copy_info,
             copy_lib,
             designspace.default.location,
@@ -285,8 +289,9 @@ class Instantiator:
         # Info
         self._generate_instance_info(instance, location_normalized, location, font)
 
-        # Groups
-        for key, glyph_names in self.copy_groups.items():
+        # Non-kerning groups. Kerning groups have been taken care of by the kerning
+        # instance.
+        for key, glyph_names in self.copy_nonkerning_groups.items():
             font.groups[key] = [name for name in glyph_names]
 
         # Features

--- a/tests/data/DesignspaceTest/MyFont-Light.ufo/groups.plist
+++ b/tests/data/DesignspaceTest/MyFont-Light.ufo/groups.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>nonkerning_group</key>
+    <array>
+      <string>A</string>
+    </array>
+    <key>public.kern2.asdf</key>
+    <array>
+      <string>A</string>
+    </array>
+  </dict>
+</plist>

--- a/tests/test_instantiator.py
+++ b/tests/test_instantiator.py
@@ -255,6 +255,19 @@ def test_raise_anisotropic_location(data_dir):
         )
 
 
+def test_copy_nonkerning_group(data_dir):
+    designspace = designspaceLib.DesignSpaceDocument.fromfile(
+        data_dir / "DesignspaceTest" / "DesignspaceTest.designspace"
+    )
+    generator = fontmake.instantiator.Instantiator.from_designspace(designspace)
+
+    instance_font = generator.generate_instance(designspace.instances[0])
+    assert instance_font.groups == {
+        "nonkerning_group": ["A"],
+        "public.kern2.asdf": ["A"],
+    }
+
+
 def test_interpolation(data_dir):
     designspace = designspaceLib.DesignSpaceDocument.fromfile(
         data_dir / "DesignspaceTest" / "DesignspaceTest.designspace"


### PR DESCRIPTION
ufoProcessor does the same: https://github.com/LettError/ufoProcessor/blob/c23240dc20922fed84b458632041310dea526c2d/Lib/ufoProcessor/__init__.py#L688-L694.

Kerning groups are taken care of by MathKerning.

This should have no user-visible impact but is more a "doing it a bit more correctly" type of change.