### PR TITLE
fontMath.mathFunctions.setRoundIntegerFunction only in fontMath>=0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cu2qu==1.6.5
 glyphsLib==4.1.2
 ufo2ft[pathops]==2.9.1
 MutatorMath==2.1.2
+fontMath>=0.5.0
 defcon[lxml]==0.6.0
 booleanOperations==0.8.2
 skia-pathops==0.2.0.post2

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "glyphsLib>=4.1.2",
         "ufo2ft>=2.9.1",
         "MutatorMath>=2.1.2",
+        "fontMath>=0.5.0",
         "defcon[lxml]>=0.6.0",
         "booleanOperations>=0.8.2",
         "ufoLib2>=0.4.0",


### PR DESCRIPTION
When fontmath is already installed, upgrading fontmake should also upgrade it to the minimum requirement.

The required version of MutatorMath could require fontMath>=0.5.0 instead but it actually doesn’t use `setRoundIntegerFunction`.