### PR TITLE
fix interaction with skipExportGlyphs and post-build subsetting feature

### DIFF
--- a/tests/data/TestSubset.glyphs
+++ b/tests/data/TestSubset.glyphs
@@ -208,6 +208,7 @@ unicode = 0043;
 },
 {
 glyphname = B;
+export = 0;
 lastChange = "2018-06-15 11:34:17 +0000";
 layers = (
 {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -303,31 +303,40 @@ def test_ufo_interpolation_specific(data_dir, tmp_path):
     }
 
 
-def test_subsetting(data_dir, tmp_path):
+@pytest.mark.parametrize(
+    "write_skipexportglyphs",
+    [
+        pytest.param(True, id="default"),
+        pytest.param(False, id="no-write-skipexportglyphs"),
+    ],
+)
+def test_subsetting(data_dir, tmp_path, write_skipexportglyphs):
     shutil.copyfile(data_dir / "TestSubset.glyphs", tmp_path / "TestSubset.glyphs")
 
-    fontmake.__main__.main(
-        [
-            "-g",
-            str(tmp_path / "TestSubset.glyphs"),
-            "--master-dir",
-            str(tmp_path / "master_ufos"),
-            "--instance-dir",
-            str(tmp_path / "instance_ufos"),
-            "-i",
-            "Test Subset Regular",
-            "-o",
-            "ttf",
-            "otf",
-            "--output-dir",
-            str(tmp_path),
-        ]
-    )
+    args = [
+        "-g",
+        str(tmp_path / "TestSubset.glyphs"),
+        "--master-dir",
+        str(tmp_path / "master_ufos"),
+        "--instance-dir",
+        str(tmp_path / "instance_ufos"),
+        "-i",
+        "Test Subset Regular",
+        "-o",
+        "ttf",
+        "otf",
+        "--output-dir",
+        str(tmp_path),
+    ]
+    if not write_skipexportglyphs:
+        args.append("--no-write-skipexportglyphs")
+
+    fontmake.__main__.main(args)
 
     for output_format in ("ttf", "otf"):
         for font_path in tmp_path.glob("*." + output_format):
             font = fontTools.ttLib.TTFont(font_path)
-            assert font.getGlyphOrder() == [".notdef", "space", "A", "C", "B"]
+            assert font.getGlyphOrder() == [".notdef", "space", "A", "C"]
 
 
 def test_shared_features_expansion(data_dir, tmp_path):


### PR DESCRIPTION
when an instance has "Keep Glyphs" custom parameter, fontmake runs the fonttools subsetter on the OTF just built and prunes all glyphs not present in that list. Since the postscript glyph names in OTF may have been renamed using final production uni-names, fontmake needs to match the original glyph names in UFO and the ones in the OTF by their glyph index.
   
Now that glyphsLib/ufo2ft support the `public.skipExportGlyphs` option, and fontmake enables this feature by default  (unless `--no-write-skipexportglyphs` option is passed), this means that the built OTF may contain less glyphs than the original UFO (glyphs in public.skipExportGlyphs are not exported) and so we hit as AssertionError as the two glyphOrder have different lengths.

This fixes the problem by only considering the actually exported glyphs when extracting the glyphOrder from the UFO in the process of subsetting the OTF.

A test is added to make sure we get the same final subsetted glyphOrder, whether `--no-write-skipexportglyphs` option is used or not.