### PR TITLE
instantiator: when applying DS rules, must also swap anchors

### DIFF
--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -582,17 +582,24 @@ def swap_glyph_names(font: ufoLib2.Font, name_old: str, name_new: str):
     glyph_old.drawPoints(p)
     glyph_swap.width = glyph_old.width
 
-    glyph_old.clear()
+    glyph_old.clearContours()
+    glyph_old.clearComponents()
     p = glyph_old.getPointPen()
     glyph_new.drawPoints(p)
     glyph_old.width = glyph_new.width
 
-    glyph_new.clear()
+    glyph_new.clearContours()
+    glyph_new.clearComponents()
     p = glyph_new.getPointPen()
     glyph_swap.drawPoints(p)
     glyph_new.width = glyph_swap.width
 
-    # 2. Remap components.
+    # 2. Swap anchors.
+    glyph_swap.anchors = glyph_old.anchors
+    glyph_old.anchors = glyph_new.anchors
+    glyph_new.anchors = glyph_swap.anchors
+
+    # 3. Remap components.
     for g in font:
         for c in g.components:
             if c.baseGlyph == name_old:
@@ -600,7 +607,7 @@ def swap_glyph_names(font: ufoLib2.Font, name_old: str, name_new: str):
             elif c.baseGlyph == name_new:
                 c.baseGlyph = name_old
 
-    # 3. Swap literal names in kerning.
+    # 4. Swap literal names in kerning.
     kerning_new = {}
     for first, second in font.kerning.keys():
         value = font.kerning[(first, second)]
@@ -615,7 +622,7 @@ def swap_glyph_names(font: ufoLib2.Font, name_old: str, name_new: str):
         kerning_new[(first, second)] = value
     font.kerning = kerning_new
 
-    # 4. Swap names in groups.
+    # 5. Swap names in groups.
     for group_name, group_members in font.groups.items():
         group_members_new = []
         for name in group_members:

--- a/tests/data/SwapGlyphNames/A.ufo/glyphs/a.glif
+++ b/tests/data/SwapGlyphNames/A.ufo/glyphs/a.glif
@@ -2,6 +2,8 @@
 <glyph name="a" format="2">
   <advance width="600"/>
   <unicode hex="0061"/>
+  <anchor x="351" y="0" name="bottom"/>
+  <anchor x="351" y="613" name="top"/>
   <outline>
     <contour>
       <point x="113.0" y="500.0" type="line"/>

--- a/tests/data/SwapGlyphNames/A.ufo/glyphs/a.swap.glif
+++ b/tests/data/SwapGlyphNames/A.ufo/glyphs/a.swap.glif
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="a.swap" format="2">
   <advance width="666.0"/>
+  <anchor x="153" y="0" name="bottom"/>
+  <anchor x="153" y="316" name="top"/>
   <outline>
     <contour>
       <point x="127" y="500" type="line"/>

--- a/tests/test_instantiator.py
+++ b/tests/test_instantiator.py
@@ -3,6 +3,7 @@ import logging
 import fontTools.designspaceLib as designspaceLib
 import pytest
 import ufoLib2
+from ufoLib2.objects.anchor import Anchor
 
 import fontmake.instantiator
 
@@ -139,6 +140,16 @@ def test_swap_glyph_names(data_dir):
         "x",
     ]
     assert sorted(c.baseGlyph for c in ufo["aaa.swap"].components) == ["a", "a", "y"]
+
+    # Test swapped anchors.
+    assert ufo["a"].anchors == [
+        Anchor(x=153, y=0, name="bottom"),
+        Anchor(x=153, y=316, name="top"),
+    ]
+    assert ufo["a.swap"].anchors == [
+        Anchor(x=351, y=0, name="bottom"),
+        Anchor(x=351, y=613, name="top"),
+    ]
 
     # Test swapped glyph kerning.
     assert ufo.kerning == {


### PR DESCRIPTION
Glyph.clear() destroys all anchors (and pen protocol does not 'draw' them).
`fontmake.instantiator` needs to also swap the glyph anchors when applying the DesignSpace conditional substitution rules, just like it does for the contours and components.
Otherwise, the swapped glyphs will lose all their anchors and get no mark/mkmk features...

**NOTE**: If you used fontmake to generate fonts that contain "bracket" glyphs or a DesignSpace document with rvrn-style conditional substitution rules, and these glyphs contain any anchors which were supposed to be used to generate mark or mkmk feature, I strongly recommend that you re-generate your fonts using the new fontmake and glyphsLib (which we are going to release shortly after this is merged).

Apologies, we should have caught this earlier.
Many thanks @chrissimpkins and @danielgrumer for reporting this bug (and this one too https://github.com/googlefonts/glyphsLib/issues/578).