### PR TITLE
Update --mti-source help string

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -323,7 +323,7 @@ def main(args=None):
     feaCompilerGroup = layoutGroup.add_mutually_exclusive_group(required=False)
     feaCompilerGroup.add_argument(
         "--mti-source",
-        help="Path to mtiLib .txt feature definitions (use instead of FEA)",
+        help="mtiLib feature definition .plist file path (use instead of FEA)",
     )
 
     glyphnamesGroup = parser.add_mutually_exclusive_group(required=False)


### PR DESCRIPTION
I compiled [Noto Nastaliq Urdu](https://github.com/googlefonts/noto-source/tree/master/src/NotoNastaliqUrdu) today and was confused by the help string for the fontmake `--mti-source` option.  This build uses the [Monotype OpenType Layout Source](https://monotype.github.io/OpenType_Table_Source/otl_source.html) format with a combination of multiple `*.txt` files and a single `*.plist` file for GSUB, GPOS, and GDEF table definitions.  The fontmake help menu indicates that the command line argument is the "Path to mtiLib .txt feature definitions".  This PR clarifies that the plist file path is the required command line argument.