### PR TITLE
Produce better error messages

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import sys
 from argparse import ArgumentParser, FileType
 from contextlib import contextmanager
 
@@ -413,6 +415,7 @@ def main(args=None):
                     "[mutatormath] extra"
                 )
 
+    PRINT_TRACEBACK = args.get("verbose", "INFO") == "DEBUG"
     try:
         project = FontProject(
             timing=args.pop("timing"),
@@ -460,12 +463,11 @@ def main(args=None):
             ufo_paths, is_instance=args.pop("masters_as_instances"), **args
         )
     except FontmakeError as e:
-        import sys
-
-        sys.exit("fontmake: error: %s" % e)
+        if PRINT_TRACEBACK:
+            logging.exception(e)
+            sys.exit(1)
+        sys.exit(f"fontmake: Error: {str(e)}")
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(main())

--- a/Lib/fontmake/errors.py
+++ b/Lib/fontmake/errors.py
@@ -1,12 +1,43 @@
-class FontmakeError(Exception):
-    """Base class for all fontmake exceptions."""
+import os
 
-    pass
+
+class FontmakeError(Exception):
+    """Base class for all fontmake exceptions.
+
+    This exception is intended to be chained to the original exception. The
+    main purpose is to provide a source file trail that points to where the
+    explosion came from.
+    """
+
+    def __init__(self, msg, source_file):
+        self.msg = msg
+        self.source_trail = [source_file]
+
+    def __str__(self):
+        trail = " -> ".join(
+            f"'{str(os.path.relpath(s))}'"
+            for s in reversed(self.source_trail)
+            if s is not None
+        )
+        cause = str(self.__cause__) if self.__cause__ is not None else None
+
+        message = ""
+        if trail:
+            message = f"In {trail}: "
+        message += f"{self.msg}"
+        if cause:
+            message += f": {cause}"
+
+        return message
 
 
 class TTFAError(FontmakeError):
-    def __init__(self, exitcode):
+    def __init__(self, exitcode, source_file):
         self.exitcode = exitcode
+        self.source_trail = source_file
 
     def __str__(self):
-        return "ttfautohint command failed: error " + str(self.exitcode)
+        return (
+            f"ttfautohint failed for '{str(os.path.relpath(self.source_trail))}': "
+            f"error code {str(self.exitcode)}."
+        )

--- a/Lib/fontmake/ttfautohint.py
+++ b/Lib/fontmake/ttfautohint.py
@@ -15,7 +15,7 @@
 
 import subprocess
 
-from fontmake.errors import TTFAError
+from fontmake.errors import TTFAError, FontmakeError
 
 
 def ttfautohint(in_file, out_file, args=None, **kwargs):
@@ -31,9 +31,14 @@ def ttfautohint(in_file, out_file, args=None, **kwargs):
     if args is not None:
         if kwargs:
             raise TypeError("Should not provide both cmd args and kwargs.")
-        rv = subprocess.call(arg_list + args.split() + file_args)
+        try:
+            rv = subprocess.call(arg_list + args.split() + file_args)
+        except OSError as e:
+            raise FontmakeError(
+                "Could not launch ttfautohint (is it installed?)", in_file
+            ) from e
         if rv != 0:
-            raise TTFAError(rv)
+            raise TTFAError(rv, in_file)
         return
 
     boolean_options = (
@@ -79,4 +84,4 @@ def ttfautohint(in_file, out_file, args=None, **kwargs):
 
     rv = subprocess.call(arg_list + file_args)
     if rv != 0:
-        raise TTFAError(rv)
+        raise TTFAError(rv, in_file)


### PR DESCRIPTION
TODO:
- [x] Wrap all of varLib's `AssertionError`s in `VarLibError` when calling `build()` so we can catch them more easily in fontmake
- [x] Optionally do something about feaLib errors? `IncludedFeaNotFound` needs a proper warning text saying that an include could not be found.