### PR TITLE
Ensure only the default groups are used in interpolation

### DIFF
--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -502,6 +502,15 @@ def collect_kerning_masters(
         if source.layerName is not None:
             continue  # No kerning in source layers.
 
+        # If a source has groups, they should match the default's.
+        if source.font.groups and source.font.groups != groups:
+            logger.warning(
+                "The source %s (%s) contains different groups than the default source. "
+                "The default source's groups will be used for the instances.",
+                source.name,
+                source.filename,
+            )
+
         # This assumes that groups of all sources are the same.
         normalized_location = varLib.models.normalizeLocation(
             source.location, axis_bounds

--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -227,7 +227,7 @@ class Instantiator:
                 f"Cannot set up kerning for interpolation: {e}'"
             ) from e
 
-        default_font = designspace.findDefault().font
+        default_font = designspace.default.font
         glyph_mutators: Dict[str, Variator] = {}
         glyph_name_to_unicodes: Dict[str, List[int]] = {}
         for glyph_name in glyph_names:
@@ -492,6 +492,11 @@ def collect_kerning_masters(
     designspace: designspaceLib.DesignSpaceDocument, axis_bounds: AxisBounds
 ) -> List[Tuple[Location, FontMathObject]]:
     """Return master kerning objects wrapped by MathKerning."""
+
+    # Always take the groups from the default source. This also avoids fontMath
+    # making a union of all groups it is given.
+    groups = designspace.default.font.groups
+
     locations_and_masters = []
     for source in designspace.sources:
         if source.layerName is not None:
@@ -502,10 +507,7 @@ def collect_kerning_masters(
             source.location, axis_bounds
         )
         locations_and_masters.append(
-            (
-                normalized_location,
-                fontMath.MathKerning(source.font.kerning, source.font.groups),
-            )
+            (normalized_location, fontMath.MathKerning(source.font.kerning, groups))
         )
 
     return locations_and_masters

--- a/tests/test_instantiator.py
+++ b/tests/test_instantiator.py
@@ -60,6 +60,33 @@ def test_interpolation_weight_width_class(data_dir):
     assert font.info.openTypeOS2WidthClass == 9
 
 
+def test_default_groups_only(data_dir):
+    d = designspaceLib.DesignSpaceDocument()
+    d.addAxisDescriptor(
+        name="Weight", tag="wght", minimum=300, default=300, maximum=900
+    )
+    d.addSourceDescriptor(location={"Weight": 300}, font=ufoLib2.Font())
+    d.addSourceDescriptor(location={"Weight": 900}, font=ufoLib2.Font())
+    d.addInstanceDescriptor(styleName="2", location={"Weight": 400})
+    d.findDefault()
+
+    d.sources[0].font.groups["public.kern1.GRK_alpha_alt_LC_1ST"] = [
+        "alpha.alt",
+        "alphatonos.alt",
+    ]
+    d.sources[1].font.groups["public.kern1.GRK_alpha_LC_1ST"] = [
+        "alpha.alt",
+        "alphatonos.alt",
+    ]
+
+    generator = fontmake.instantiator.Instantiator.from_designspace(d)
+    instance = generator.generate_instance(d.instances[0])
+
+    assert instance.groups == {
+        "public.kern1.GRK_alpha_alt_LC_1ST": ["alpha.alt", "alphatonos.alt"]
+    }
+
+
 def test_interpolation_no_rounding(data_dir):
     designspace = designspaceLib.DesignSpaceDocument.fromfile(
         data_dir / "MutatorSans" / "MutatorSans.designspace"


### PR DESCRIPTION
The intention (and varLib's behavior probably) is to only use the default source's groups for kerning group information. Before this PR, we accidentally had Instantiator use the groups associated with each source individually. fontMath makes a union of them, which is fine if all groups are the same, but leads to problems otherwise.

ufoProcessor suffers from the same problems and assumes groups are identical: https://github.com/LettError/ufoProcessor/blob/88323a4/Lib/ufoProcessor/__init__.py#L392-L393