### PR TITLE
Use default glyphs for interpolation

### DIFF
--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -192,14 +192,14 @@ class Instantiator:
 
         designspace.loadSourceFonts(ufoLib2.Font.open)
 
-        # The default font determines which glyphs are interpolated, because the math
-        # behind varLib and MutatorMath needs the default font as a point of reference
-        # for all data to be interpolated.
+        # The default font (default layer) determines which glyphs are interpolated,
+        # because the math behind varLib and MutatorMath uses the default font as the
+        # point of reference for all data.
         default_font = designspace.default.font
-        glyph_names: Set[str] = set(default_font.layers.defaultLayer.keys())
+        glyph_names: Set[str] = set(default_font.keys())
 
         for source in designspace.sources:
-            other_names = set(source.font.layers.defaultLayer.keys())
+            other_names = set(source.font.keys())
             diff_names = other_names - glyph_names
             if diff_names:
                 logger.warning(

--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -192,9 +192,25 @@ class Instantiator:
 
         designspace.loadSourceFonts(ufoLib2.Font.open)
 
-        glyph_names: Set[str] = set()
+        # The default font determines which glyphs are interpolated, because the math
+        # behind varLib and MutatorMath needs the default font as a point of reference
+        # for all data to be interpolated.
+        default_font = designspace.default.font
+        glyph_names: Set[str] = set(default_font.layers.defaultLayer.keys())
+
         for source in designspace.sources:
-            glyph_names.update(source.font.keys())
+            other_names = set(source.font.layers.defaultLayer.keys())
+            diff_names = other_names - glyph_names
+            if diff_names:
+                logger.warning(
+                    "The source %s (%s) has more glyphs than the default source, which "
+                    "will be ignored: %s. If this is unintended, check that these "
+                    "glyphs have the exact same name as the corresponding glyphs in "
+                    "the default source.",
+                    source.name,
+                    source.filename,
+                    ", ".join(sorted(diff_names)),
+                )
 
         # Construct Variators
         axis_bounds: AxisBounds = {}  # Design space!
@@ -227,7 +243,6 @@ class Instantiator:
                 f"Cannot set up kerning for interpolation: {e}'"
             ) from e
 
-        default_font = designspace.default.font
         glyph_mutators: Dict[str, Variator] = {}
         glyph_name_to_unicodes: Dict[str, List[int]] = {}
         for glyph_name in glyph_names:

--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -203,7 +203,7 @@ class Instantiator:
             diff_names = other_names - glyph_names
             if diff_names:
                 logger.warning(
-                    "The source %s (%s) has more glyphs than the default source, which "
+                    "The source %s (%s) contains glyphs that are missing from the default source, which "
                     "will be ignored: %s. If this is unintended, check that these "
                     "glyphs have the exact same name as the corresponding glyphs in "
                     "the default source.",

--- a/tests/test_instantiator.py
+++ b/tests/test_instantiator.py
@@ -348,6 +348,25 @@ def test_interpolation(data_dir):
     assert instance_font["l"].width == 220
 
 
+def test_interpolation_only_default(data_dir, caplog):
+    designspace = designspaceLib.DesignSpaceDocument.fromfile(
+        data_dir / "MutatorSans" / "MutatorSans.designspace"
+    )
+    designspace.loadSourceFonts(ufoLib2.Font.open)
+    for name in designspace.default.font.glyphOrder:
+        if name != "A":
+            del designspace.default.font[name]
+
+    with caplog.at_level(logging.WARNING):
+        generator = fontmake.instantiator.Instantiator.from_designspace(
+            designspace, round_geometry=True
+        )
+    assert "has more glyphs than the default source" in caplog.text
+
+    instance_font = generator.generate_instance(designspace.instances[0])
+    assert {g.name for g in instance_font} == {"A"}
+
+
 def test_interpolation_masters_as_instances(data_dir):
     designspace = designspaceLib.DesignSpaceDocument.fromfile(
         data_dir


### PR DESCRIPTION
The default font determines which glyphs are interpolated, because the math behind varLib and MutatorMath needs the default font as a point of reference for all data to be interpolated.