### PR TITLE
support subroutinizing with cffsubr; add otf-cff2 static output

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -124,6 +124,7 @@ def main(args=None):
         choices=(
             "ufo",
             "otf",
+            "otf-cff2",
             "ttf",
             "ttf-interpolatable",
             "otf-interpolatable",
@@ -279,6 +280,14 @@ def main(args=None):
         default=CFFOptimization.SUBROUTINIZE,
         help="0 disables all optimizations; 1 specializes the CFF charstring "
         "operators; 2 (default) also enables subroutinization",
+    )
+    contourGroup.add_argument(
+        "--subroutinizer",
+        default=None,
+        choices=["compreffor", "cffsubr"],
+        help="name of the library to use for compressing CFF charstrings. "
+        "Choose between: %(choices)s. By default compreffor is used for CFF 1, "
+        "and cffsubr for CFF2. NOTE: compreffor doesn't support CFF2.",
     )
     contourGroup.add_argument(
         "--no-optimize-gvar",

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -1050,8 +1050,8 @@ class FontProject:
             )
 
         need_reload = False
-        if "otf" in output or "otf-cff2" in output:
-            cff_version = 2 if "otf-cff2" in output else 1
+        cff_version = 1 if "otf" in output else 2 if "otf-cff2" in output else None
+        if cff_version is not None:
             self.build_otfs(ufos, cff_version=cff_version, **kwargs)
             need_reload = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fonttools[lxml,unicode,ufo]==4.11.0
 cu2qu==1.6.7
 glyphsLib==5.1.10
-ufo2ft[pathops]==2.15.0b2
+ufo2ft[pathops]==2.15.0
 MutatorMath==2.1.2
 fontMath==0.6.0
 defcon[lxml]==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 fonttools[lxml,unicode,ufo]==4.11.0
 cu2qu==1.6.7
 glyphsLib==5.1.10
-ufo2ft[pathops,cffsubr]==2.15.0b2
+ufo2ft[pathops]==2.15.0b2
 MutatorMath==2.1.2
 fontMath==0.6.0
 defcon[lxml]==0.6.0
 booleanOperations==0.9.0
 ufoLib2==0.7.1
 attrs==19.3.0
+cffsubr==0.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools[lxml,unicode,ufo]==4.10.2
+fonttools[lxml,unicode,ufo]==4.11.0
 cu2qu==1.6.7
 glyphsLib==5.1.10
 ufo2ft[pathops,cffsubr]==2.15.0b2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fonttools[lxml,unicode,ufo]==4.10.2
 cu2qu==1.6.7
 glyphsLib==5.1.10
-ufo2ft[pathops]==2.14.0
+ufo2ft[pathops,cffsubr]==2.15.0b2
 MutatorMath==2.1.2
 fontMath==0.6.0
 defcon[lxml]==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "fonttools[ufo,lxml,unicode]>=4.10.2",
         "cu2qu>=1.6.7",
         "glyphsLib>=5.1.10",
-        "ufo2ft>=2.14.0",
+        "ufo2ft[cffsubr]>=2.15.0b2",
         "fontMath>=0.6.0",
         "booleanOperations>=0.9.0",
         "ufoLib2>=0.7.1",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     setup_requires=wheel + ["setuptools_scm"],
     python_requires=">=3.6",
     install_requires=[
-        "fonttools[ufo,lxml,unicode]>=4.10.2",
+        "fonttools[ufo,lxml,unicode]>=4.11.0",
         "cu2qu>=1.6.7",
         "glyphsLib>=5.1.10",
         "ufo2ft[cffsubr]>=2.15.0b2",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "fonttools[ufo,lxml,unicode]>=4.11.0",
         "cu2qu>=1.6.7",
         "glyphsLib>=5.1.10",
-        "ufo2ft[cffsubr]>=2.15.0b2",
+        "ufo2ft[cffsubr]>=2.15.0",
         "fontMath>=0.6.0",
         "booleanOperations>=0.9.0",
         "ufoLib2>=0.7.1",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -625,3 +625,35 @@ def test_debug_feature_file(data_dir, tmp_path):
 
     assert "### GlyphsUnitTestSans-Regular" in features
     assert "### GlyphsUnitTestSans-Black" in features
+
+
+def test_ufo_to_static_otf_cff2(data_dir, tmp_path):
+    fontmake.__main__.main(
+        [
+            "-u",
+            str(data_dir / "DesignspaceTest" / "MyFont-Light.ufo"),
+            "-o",
+            "otf-cff2",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert {p.name for p in tmp_path.glob("*.otf")} == {"MyFont-Light.otf"}
+
+
+def test_static_otf_cffsubr_subroutinizer(data_dir, tmp_path):
+    fontmake.__main__.main(
+        [
+            "-u",
+            str(data_dir / "DesignspaceTest" / "MyFont-Light.ufo"),
+            "-o",
+            "otf",
+            "--subroutinizer",
+            "cffsubr",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert {p.name for p in tmp_path.glob("*.otf")} == {"MyFont-Light.otf"}


### PR DESCRIPTION
Uses the latest ufo2ft with cffsubr support to allow subroutinizing CFF2 tables.
Also adds a new 'otf-cff2' output format, for non-variable CFF2 fonts