### PR TITLE
Fix two problems: non-determinism and incorrect rule application in instanciator

### DIFF
--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -153,7 +153,7 @@ class InstantiatorError(Exception):
     pass
 
 
-def processRulesSwaps(rules, location, glyphNames):
+def process_rules_swaps(rules, location, glyphNames):
     """ Apply these rules at this location to these glyphnames
         - rule order matters
 
@@ -397,7 +397,7 @@ class Instantiator:
         glyph_names_list = self.glyph_mutators.keys()
         # The order of the swaps below is independent of the order of glyph names.
         # It depends on the order of the <sub>s in the designspace rules.
-        swaps = processRulesSwaps(self.designspace_rules, location, glyph_names_list)
+        swaps = process_rules_swaps(self.designspace_rules, location, glyph_names_list)
         for name_old, name_new in swaps:
             if name_old != name_new:
                 swap_glyph_names(font, name_old, name_new)

--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -153,6 +153,26 @@ class InstantiatorError(Exception):
     pass
 
 
+def processRulesSwaps(rules, location, glyphNames):
+    """ Apply these rules at this location to these glyphnames
+        - rule order matters
+
+        Return a list of (oldName, newName) in the same order as the rules.
+    """
+    swaps = []
+    glyphNames = set(glyphNames)
+    for rule in rules:
+        if designspaceLib.evaluateRule(rule, location):
+            for oldName, newName in rule.subs:
+                # Here I don't check if the new name is also in glyphNames...
+                # I guess it should be, so that we can swap, and if it isn't,
+                # then it's better to error out later when we try to swap,
+                # instead of silently ignoring the rule here.
+                if oldName in glyphNames:
+                    swaps.append((oldName, newName))
+    return swaps
+
+
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class Instantiator:
     """Data class that holds all necessary information to generate a static
@@ -375,10 +395,10 @@ class Instantiator:
 
         # Process rules
         glyph_names_list = self.glyph_mutators.keys()
-        glyph_names_list_renamed = designspaceLib.processRules(
-            self.designspace_rules, location, glyph_names_list
-        )
-        for name_old, name_new in zip(glyph_names_list, glyph_names_list_renamed):
+        # The order of the swaps below is independent of the order of glyph names.
+        # It depends on the order of the <sub>s in the designspace rules.
+        swaps = processRulesSwaps(self.designspace_rules, location, glyph_names_list)
+        for name_old, name_new in swaps:
             if name_old != name_new:
                 swap_glyph_names(font, name_old, name_new)
 

--- a/tests/data/DesignspaceRuleOrder/MyFont.designspace
+++ b/tests/data/DesignspaceRuleOrder/MyFont.designspace
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+    <axes>
+        <axis tag="wght" name="Weight" minimum="100" maximum="900" default="100" />
+        <axis tag="STYL" name="Style" minimum="0" maximum="1" default="0"/>
+    </axes>
+
+    <rules processing="last">
+        <rule>
+            <conditionset>
+                <condition name="Weight" minimum="780"/>
+            </conditionset>
+            <sub name="Q" with="Q.alt"/>
+        </rule>
+
+        <rule>
+            <conditionset>
+                <condition name="Weight" minimum="730"/>
+            </conditionset>
+            <sub name="Q.ss01" with="Q.ss01.alt"/>
+        </rule>
+
+        <rule>
+            <conditionset>
+                <condition name="Style" minimum="0.5" maximum="1"/>
+            </conditionset>
+            <sub name="Q" with="Q.ss01"/>
+            <sub name="Q.alt" with="Q.ss01.alt"/>
+        </rule>
+    </rules>
+
+    <sources>
+        <source filename="MyFont_Hair.ufo" name="MyFont Hairline" familyname="MyFont" stylename="Hairline">
+            <lib copy="1"/>
+            <groups copy="1"/>
+            <features copy="1"/>
+            <info copy="1"/>
+            <location>
+                <dimension name="Weight" xvalue="100"/>
+                <dimension name="Style" xvalue="0"/>
+            </location>
+        </source>
+        <source filename="MyFont_Black.ufo" name="MyFont Black" familyname="MyFont" stylename="Black">
+            <location>
+                <dimension name="Weight" xvalue="900"/>
+                <dimension name="Style" xvalue="0"/>
+            </location>
+        </source>
+    </sources>
+
+    <instances>
+        <instance name="MyFont Style Black" familyname="MyFont" stylename="Style Black" filename="instance_ufos/MyFont_StyleBlack.ufo">
+            <location>
+                <dimension name="Weight" xvalue="900"/>
+                <dimension name="Style" xvalue="0.5"/>
+            </location>
+            <kerning/>
+            <info/>
+        </instance>
+    </instances>
+</designspace>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/fontinfo.plist
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/fontinfo.plist
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>0</integer>
+    <key>capHeight</key>
+    <integer>0</integer>
+    <key>descender</key>
+    <integer>0</integer>
+    <key>familyName</key>
+    <string>MyFont</string>
+    <key>guidelines</key>
+    <array/>
+    <key>postscriptBlueValues</key>
+    <array/>
+    <key>postscriptFamilyBlues</key>
+    <array/>
+    <key>postscriptFamilyOtherBlues</key>
+    <array/>
+    <key>postscriptOtherBlues</key>
+    <array/>
+    <key>postscriptStemSnapH</key>
+    <array/>
+    <key>postscriptStemSnapV</key>
+    <array/>
+    <key>styleName</key>
+    <string>Black</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>xHeight</key>
+    <integer>0</integer>
+  </dict>
+</plist>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/glyphs/Q_.alt.glif
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/glyphs/Q_.alt.glif
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.alt" format="2">
+	<advance width="800"/>
+	<outline>
+		<contour>
+			<point x="394" y="-25" type="curve" smooth="yes"/>
+			<point x="449" y="-25"/>
+			<point x="501" y="-11"/>
+			<point x="546" y="14" type="curve"/>
+			<point x="655" y="81" type="line"/>
+			<point x="728" y="142"/>
+			<point x="773" y="234"/>
+			<point x="773" y="345" type="curve" smooth="yes"/>
+			<point x="773" y="565"/>
+			<point x="610" y="715"/>
+			<point x="394" y="715" type="curve" smooth="yes"/>
+			<point x="178" y="715"/>
+			<point x="15" y="565"/>
+			<point x="15" y="345" type="curve" smooth="yes"/>
+			<point x="15" y="125"/>
+			<point x="178" y="-25"/>
+		</contour>
+		<contour>
+			<point x="394" y="255" type="curve" smooth="yes"/>
+			<point x="345" y="255"/>
+			<point x="305" y="292"/>
+			<point x="305" y="345" type="curve" smooth="yes"/>
+			<point x="305" y="398"/>
+			<point x="345" y="435"/>
+			<point x="394" y="435" type="curve" smooth="yes"/>
+			<point x="443" y="435"/>
+			<point x="483" y="398"/>
+			<point x="483" y="345" type="curve" smooth="yes"/>
+			<point x="483" y="292"/>
+			<point x="443" y="255"/>
+		</contour>
+		<contour>
+			<point x="562" y="-83" type="line"/>
+			<point x="862" y="-83" type="line"/>
+			<point x="862" y="-74" type="line"/>
+			<point x="654" y="188" type="line"/>
+			<point x="409" y="87" type="line"/>
+		</contour>
+	</outline>
+	<guideline x="-33" y="679" angle="317"/>
+</glyph>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/glyphs/Q_.glif
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/glyphs/Q_.glif
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q" format="2">
+	<unicode hex="0051"/>
+	<advance width="800"/>
+	<outline>
+		<contour>
+			<point x="394" y="-23" type="curve" smooth="yes"/>
+			<point x="451" y="-23"/>
+			<point x="504" y="-15"/>
+			<point x="551" y="4" type="curve"/>
+			<point x="647" y="61" type="line"/>
+			<point x="725" y="127"/>
+			<point x="773" y="226"/>
+			<point x="773" y="345" type="curve" smooth="yes"/>
+			<point x="773" y="565"/>
+			<point x="610" y="715"/>
+			<point x="394" y="715" type="curve" smooth="yes"/>
+			<point x="178" y="715"/>
+			<point x="15" y="565"/>
+			<point x="15" y="345" type="curve" smooth="yes"/>
+			<point x="15" y="125"/>
+			<point x="177" y="-23"/>
+		</contour>
+		<contour>
+			<point x="394" y="246" type="curve" smooth="yes"/>
+			<point x="346" y="246"/>
+			<point x="305" y="287"/>
+			<point x="305" y="345" type="curve" smooth="yes"/>
+			<point x="305" y="398"/>
+			<point x="345" y="435"/>
+			<point x="394" y="435" type="curve" smooth="yes"/>
+			<point x="443" y="435"/>
+			<point x="483" y="398"/>
+			<point x="483" y="345" type="curve" smooth="yes"/>
+			<point x="483" y="287"/>
+			<point x="443" y="246"/>
+		</contour>
+		<contour>
+			<point x="566" y="-50" type="line"/>
+			<point x="859" y="-50" type="line"/>
+			<point x="859" y="-41" type="line"/>
+			<point x="640" y="221" type="line"/>
+			<point x="407" y="121" type="line"/>
+		</contour>
+		<contour>
+			<point x="242" y="305" type="line"/>
+			<point x="397" y="148" type="line"/>
+			<point x="612" y="214" type="line"/>
+			<point x="547" y="305" type="line"/>
+		</contour>
+	</outline>
+	<guideline x="-34" y="725" angle="317"/>
+</glyph>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/glyphs/Q_.ss01.alt.glif
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/glyphs/Q_.ss01.alt.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.ss01.alt" format="2">
+	<advance width="788"/>
+	<outline>
+		<contour>
+			<point x="332" y="3" type="curve"/>
+			<point x="456" y="3" type="line"/>
+			<point x="619" y="6"/>
+			<point x="773" y="143"/>
+			<point x="773" y="345" type="curve" smooth="yes"/>
+			<point x="773" y="565"/>
+			<point x="610" y="715"/>
+			<point x="394" y="715" type="curve" smooth="yes"/>
+			<point x="178" y="715"/>
+			<point x="15" y="565"/>
+			<point x="15" y="345" type="curve" smooth="yes"/>
+			<point x="15" y="143"/>
+			<point x="169" y="6"/>
+		</contour>
+		<contour>
+			<point x="394" y="255" type="curve" smooth="yes"/>
+			<point x="345" y="255"/>
+			<point x="305" y="292"/>
+			<point x="305" y="345" type="curve" smooth="yes"/>
+			<point x="305" y="398"/>
+			<point x="345" y="435"/>
+			<point x="394" y="435" type="curve" smooth="yes"/>
+			<point x="443" y="435"/>
+			<point x="483" y="398"/>
+			<point x="483" y="345" type="curve" smooth="yes"/>
+			<point x="483" y="292"/>
+			<point x="443" y="255"/>
+		</contour>
+		<contour>
+			<point x="257" y="-107" type="line"/>
+			<point x="531" y="-107" type="line"/>
+			<point x="531" y="223" type="line"/>
+			<point x="257" y="223" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/glyphs/Q_.ss01.glif
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/glyphs/Q_.ss01.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.ss01" format="2">
+	<advance width="788"/>
+	<outline>
+		<contour>
+			<point x="332" y="3" type="curve"/>
+			<point x="456" y="3" type="line"/>
+			<point x="619" y="6"/>
+			<point x="773" y="143"/>
+			<point x="773" y="345" type="curve" smooth="yes"/>
+			<point x="773" y="565"/>
+			<point x="610" y="715"/>
+			<point x="394" y="715" type="curve" smooth="yes"/>
+			<point x="178" y="715"/>
+			<point x="15" y="565"/>
+			<point x="15" y="345" type="curve" smooth="yes"/>
+			<point x="15" y="143"/>
+			<point x="169" y="6"/>
+		</contour>
+		<contour>
+			<point x="394" y="255" type="curve" smooth="yes"/>
+			<point x="345" y="255"/>
+			<point x="305" y="292"/>
+			<point x="305" y="345" type="curve" smooth="yes"/>
+			<point x="305" y="398"/>
+			<point x="345" y="435"/>
+			<point x="394" y="435" type="curve" smooth="yes"/>
+			<point x="443" y="435"/>
+			<point x="483" y="398"/>
+			<point x="483" y="345" type="curve" smooth="yes"/>
+			<point x="483" y="292"/>
+			<point x="443" y="255"/>
+		</contour>
+		<contour>
+			<point x="257" y="-107" type="line"/>
+			<point x="531" y="-107" type="line"/>
+			<point x="531" y="301" type="line"/>
+			<point x="257" y="301" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/glyphs/contents.plist
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/glyphs/contents.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Q</key>
+    <string>Q_.glif</string>
+    <key>Q.alt</key>
+    <string>Q_.alt.glif</string>
+    <key>Q.ss01</key>
+    <string>Q_.ss01.glif</string>
+    <key>Q.ss01.alt</key>
+    <string>Q_.ss01.alt.glif</string>
+  </dict>
+</plist>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/layercontents.plist
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<array>
+		<array>
+			<string>public.default</string>
+			<string>glyphs</string>
+		</array>
+	</array>
+</plist>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/lib.plist
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/lib.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>public.glyphOrder</key>
+        <array>
+			<string>Q</string>
+			<string>Q.alt</string>
+			<string>Q.ss01</string>
+			<string>Q.ss01.alt</string>
+        </array>
+	</dict>
+</plist>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/metainfo.plist
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Black.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>creator</key>
+		<string>com.github.fonttools.ufoLib</string>
+		<key>formatVersion</key>
+		<integer>3</integer>
+	</dict>
+</plist>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/fontinfo.plist
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/fontinfo.plist
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>0</integer>
+    <key>capHeight</key>
+    <integer>0</integer>
+    <key>descender</key>
+    <integer>0</integer>
+    <key>familyName</key>
+    <string>MyFont</string>
+    <key>guidelines</key>
+    <array/>
+    <key>postscriptBlueValues</key>
+    <array/>
+    <key>postscriptFamilyBlues</key>
+    <array/>
+    <key>postscriptFamilyOtherBlues</key>
+    <array/>
+    <key>postscriptOtherBlues</key>
+    <array/>
+    <key>postscriptStemSnapH</key>
+    <array/>
+    <key>postscriptStemSnapV</key>
+    <array/>
+    <key>styleName</key>
+    <string>Hairline</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>xHeight</key>
+    <integer>0</integer>
+  </dict>
+</plist>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/glyphs/Q_.alt.glif
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/glyphs/Q_.alt.glif
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.alt" format="2">
+	<advance width="821"/>
+	<outline>
+		<contour>
+			<point x="412" y="-15" type="curve" smooth="yes"/>
+			<point x="515" y="-15"/>
+			<point x="609" y="22"/>
+			<point x="671" y="86" type="curve"/>
+			<point x="676" y="96" type="line"/>
+			<point x="737" y="159"/>
+			<point x="767" y="246"/>
+			<point x="767" y="345" type="curve" smooth="yes"/>
+			<point x="767" y="561"/>
+			<point x="615" y="705"/>
+			<point x="411" y="705" type="curve" smooth="yes"/>
+			<point x="207" y="705"/>
+			<point x="55" y="561"/>
+			<point x="55" y="345" type="curve" smooth="yes"/>
+			<point x="55" y="130"/>
+			<point x="208" y="-15"/>
+		</contour>
+		<contour>
+			<point x="412" y="9" type="curve" smooth="yes"/>
+			<point x="225" y="9"/>
+			<point x="81" y="145"/>
+			<point x="81" y="345" type="curve" smooth="yes"/>
+			<point x="81" y="546"/>
+			<point x="224" y="681"/>
+			<point x="411" y="681" type="curve" smooth="yes"/>
+			<point x="598" y="681"/>
+			<point x="741" y="546"/>
+			<point x="741" y="345" type="curve" smooth="yes"/>
+			<point x="741" y="135"/>
+			<point x="597" y="9"/>
+		</contour>
+		<contour>
+			<point x="763" y="0" type="line"/>
+			<point x="794" y="0" type="line"/>
+			<point x="794" y="3" type="line"/>
+			<point x="665" y="110" type="line"/>
+			<point x="646" y="98" type="line"/>
+		</contour>
+	</outline>
+	<guideline x="-28" y="657" angle="317"/>
+</glyph>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/glyphs/Q_.glif
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/glyphs/Q_.glif
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q" format="2">
+	<unicode hex="0051"/>
+	<advance width="822"/>
+	<outline>
+		<contour>
+			<point x="412" y="-15" type="curve" smooth="yes"/>
+			<point x="515" y="-15"/>
+			<point x="609" y="22"/>
+			<point x="671" y="86" type="curve"/>
+			<point x="676" y="96" type="line"/>
+			<point x="737" y="159"/>
+			<point x="767" y="246"/>
+			<point x="767" y="345" type="curve" smooth="yes"/>
+			<point x="767" y="561"/>
+			<point x="615" y="705"/>
+			<point x="411" y="705" type="curve" smooth="yes"/>
+			<point x="207" y="705"/>
+			<point x="55" y="561"/>
+			<point x="55" y="345" type="curve" smooth="yes"/>
+			<point x="55" y="130"/>
+			<point x="208" y="-15"/>
+		</contour>
+		<contour>
+			<point x="412" y="9" type="curve" smooth="yes"/>
+			<point x="225" y="9"/>
+			<point x="81" y="145"/>
+			<point x="81" y="345" type="curve" smooth="yes"/>
+			<point x="81" y="546"/>
+			<point x="224" y="681"/>
+			<point x="411" y="681" type="curve" smooth="yes"/>
+			<point x="598" y="681"/>
+			<point x="741" y="546"/>
+			<point x="741" y="345" type="curve" smooth="yes"/>
+			<point x="741" y="135"/>
+			<point x="597" y="9"/>
+		</contour>
+		<contour>
+			<point x="763" y="0" type="line"/>
+			<point x="795" y="0" type="line"/>
+			<point x="795" y="3" type="line"/>
+			<point x="673" y="105" type="line"/>
+			<point x="653" y="93" type="line"/>
+		</contour>
+		<contour>
+			<point x="408" y="301" type="line"/>
+			<point x="660" y="87" type="line"/>
+			<point x="677" y="103" type="line"/>
+			<point x="444" y="301" type="line"/>
+		</contour>
+	</outline>
+	<guideline x="-28" y="657" angle="317"/>
+</glyph>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/glyphs/Q_.ss01.alt.glif
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/glyphs/Q_.ss01.alt.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.ss01.alt" format="2">
+	<advance width="822"/>
+	<outline>
+		<contour>
+			<point x="409" y="-11" type="curve"/>
+			<point x="413" y="-11" type="line"/>
+			<point x="613" y="-11"/>
+			<point x="767" y="128"/>
+			<point x="767" y="345" type="curve" smooth="yes"/>
+			<point x="767" y="561"/>
+			<point x="615" y="705"/>
+			<point x="411" y="705" type="curve" smooth="yes"/>
+			<point x="207" y="705"/>
+			<point x="55" y="561"/>
+			<point x="55" y="345" type="curve" smooth="yes"/>
+			<point x="55" y="128"/>
+			<point x="209" y="-11"/>
+		</contour>
+		<contour>
+			<point x="411" y="13" type="curve" smooth="yes"/>
+			<point x="222" y="13"/>
+			<point x="81" y="143"/>
+			<point x="81" y="345" type="curve" smooth="yes"/>
+			<point x="81" y="546"/>
+			<point x="224" y="681"/>
+			<point x="411" y="681" type="curve" smooth="yes"/>
+			<point x="598" y="681"/>
+			<point x="741" y="546"/>
+			<point x="741" y="345" type="curve" smooth="yes"/>
+			<point x="741" y="143"/>
+			<point x="600" y="13"/>
+		</contour>
+		<contour>
+			<point x="399" y="-154" type="line"/>
+			<point x="423" y="-154" type="line"/>
+			<point x="423" y="4" type="line"/>
+			<point x="399" y="4" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/glyphs/Q_.ss01.glif
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/glyphs/Q_.ss01.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.ss01" format="2">
+	<advance width="822"/>
+	<outline>
+		<contour>
+			<point x="409" y="-11" type="curve"/>
+			<point x="413" y="-11" type="line"/>
+			<point x="613" y="-11"/>
+			<point x="767" y="128"/>
+			<point x="767" y="345" type="curve" smooth="yes"/>
+			<point x="767" y="561"/>
+			<point x="615" y="705"/>
+			<point x="411" y="705" type="curve" smooth="yes"/>
+			<point x="207" y="705"/>
+			<point x="55" y="561"/>
+			<point x="55" y="345" type="curve" smooth="yes"/>
+			<point x="55" y="128"/>
+			<point x="209" y="-11"/>
+		</contour>
+		<contour>
+			<point x="411" y="13" type="curve" smooth="yes"/>
+			<point x="222" y="13"/>
+			<point x="81" y="143"/>
+			<point x="81" y="345" type="curve" smooth="yes"/>
+			<point x="81" y="546"/>
+			<point x="224" y="681"/>
+			<point x="411" y="681" type="curve" smooth="yes"/>
+			<point x="598" y="681"/>
+			<point x="741" y="546"/>
+			<point x="741" y="345" type="curve" smooth="yes"/>
+			<point x="741" y="143"/>
+			<point x="600" y="13"/>
+		</contour>
+		<contour>
+			<point x="399" y="-154" type="line"/>
+			<point x="423" y="-154" type="line"/>
+			<point x="423" y="179" type="line"/>
+			<point x="399" y="179" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/glyphs/contents.plist
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/glyphs/contents.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Q</key>
+    <string>Q_.glif</string>
+    <key>Q.alt</key>
+    <string>Q_.alt.glif</string>
+    <key>Q.ss01</key>
+    <string>Q_.ss01.glif</string>
+    <key>Q.ss01.alt</key>
+    <string>Q_.ss01.alt.glif</string>
+  </dict>
+</plist>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/layercontents.plist
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<array>
+		<array>
+			<string>public.default</string>
+			<string>glyphs</string>
+		</array>
+	</array>
+</plist>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/lib.plist
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/lib.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>public.glyphOrder</key>
+        <array>
+			<string>Q</string>
+			<string>Q.alt</string>
+			<string>Q.ss01</string>
+			<string>Q.ss01.alt</string>
+        </array>
+	</dict>
+</plist>

--- a/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/metainfo.plist
+++ b/tests/data/DesignspaceRuleOrder/MyFont_Hair.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>creator</key>
+		<string>com.github.fonttools.ufoLib</string>
+		<key>formatVersion</key>
+		<integer>3</integer>
+	</dict>
+</plist>


### PR DESCRIPTION
Hello, I pushed here a test that reproduces a bug with the instanciator when several designspace rules touch the same glyphs. I wrote a test designspace and [a description of what should happen in the docstring of the test](https://github.com/googlefonts/fontmake/pull/689/files#diff-60bba4bf61f2028edf91b4e75a5728f2R276-R288).

Instead of the expected result, there are two problems I would like to address in this PR:
* with the rules of the designspace provided as a test case, the output is wrong
* the output is also random, which can make it right sometimes by luck

The misbehaved code is below:
https://github.com/googlefonts/fontmake/blob/f07b1932768efdee8f15a4a9179d1c2d181ceb8a/Lib/fontmake/instantiator.py#L376-L383

Here is what I get if I put a breakpoint after line 380:

```
$ fontmake -m MyFont.designspace -o ttf -i
INFO:fontmake.font_project:Interpolating master UFOs from designspace
INFO:fontmake.font_project:Generating instance UFO for "My Font Style Black"
> c:\userslocal\jany.belluz\documents\code\fontmake\lib\fontmake\instantiator.py(382)generate_instance()
-> for name_old, name_new in zip(glyph_names_list, glyph_names_list_renamed):
(Pdb) glyph_names_list
dict_keys(['Q.ss01.alt', 'Q.ss01', 'Q.alt', 'Q'])
(Pdb) glyph_names_list_renamed
['Q.ss01.alt', 'Q.ss01.alt', 'Q.ss01.alt', 'Q.ss01.alt']
```

As you can see from the contents of `glyph_names_list` and `glyph_names_list_renamed`, the `for` loop will perform the following swaps:
1. Q.ss01 <-> Q.ss01.alt
2. Q.alt <-> Q.ss01.alt
3. Q <-> Q.ss01.alt

#### Initial
| name | outlines |
|---|---|
| Q | Q |
| Q.alt | Q.alt |
| Q.ss01 | Q.ss01 |
| Q.ss01.alt | Q.ss01.alt |

#### Step 1
| name | outlines |
|---|---|
| Q | Q |
| Q.alt | Q.alt |
| Q.ss01 | Q.ss01.alt |
| Q.ss01.alt | Q.ss01 |

#### Step 2
| name | outlines |
|---|---|
| Q | Q |
| Q.alt | Q.ss01 |
| Q.ss01 | Q.ss01.alt |
| Q.ss01.alt | Q.alt |

#### Step 3 = final
| name | outlines |
|---|---|
| Q | Q.alt |
| Q.alt | Q.ss01 |
| Q.ss01 | Q.ss01.alt |
| Q.ss01.alt | Q |

The end result is not right, because what we would want is that the Q gets the outlines of Q.ss01.alt.

And if you run the command again you get a different result, because `glyph_name_list` ~~is keys from a dict~~ comes from a `set()` at some point, so the order is random, see example below:

```
$ fontmake -m MyFont.designspace -o ttf -i
INFO:fontmake.font_project:Interpolating master UFOs from designspace
INFO:fontmake.font_project:Generating instance UFO for "My Font Style Black"
> c:\userslocal\jany.belluz\documents\code\fontmake\lib\fontmake\instantiator.py(382)generate_instance()
-> for name_old, name_new in zip(glyph_names_list, glyph_names_list_renamed):
(Pdb)  glyph_names_list
dict_keys(['Q.ss01.alt', 'Q', 'Q.alt', 'Q.ss01'])        # <--- different order here
```

Thinking about this by hand, here is what I think would make sense as a series of swaps (which is basically applying the designspace rules one after the other in order):

#### Initial
| name | outlines |
|---|---|
| Q | Q |
| Q.alt | Q.alt |
| Q.ss01 | Q.ss01 |
| Q.ss01.alt | Q.ss01.alt |


#### Apply [rule 1](https://github.com/googlefonts/fontmake/pull/689/files#diff-896394abc6db517c2655cab987b3b6c4R13): Q <-> Q.alt
| name | outlines |
|---|---|
| Q | Q.alt |
| Q.alt | Q |
| Q.ss01 | Q.ss01 |
| Q.ss01.alt | Q.ss01.alt |



#### Apply [rule 2](https://github.com/googlefonts/fontmake/pull/689/files#diff-896394abc6db517c2655cab987b3b6c4R20): Q.ss01 <-> Q.ss01.alt
| name | outlines |
|---|---|
| Q | Q.alt |
| Q.alt | Q |
| Q.ss01 | Q.ss01.alt |
| Q.ss01.alt | Q.ss01 |

#### Apply [rule 3](https://github.com/googlefonts/fontmake/pull/689/files#diff-896394abc6db517c2655cab987b3b6c4R27-R28): Q <-> Q.ss01 and Q.alt <-> Q.ss01.alt
| name | outlines |
|---|---|
| Q | Q.ss01.alt |
| Q.alt | Q.ss01 |
| Q.ss01 | Q.alt |
| Q.ss01.alt | Q |

This gives a satisfying result for the main case (Q has the outlines of Q.ss01.alt) and also for the others, I feel, since the final swaps make sense (the style is changed so the ss01 has been swapped, and the weight is bold enough so the alt have been swapped). Do you agree that I should implement this result?

Next question: if I want to implement the result above, I need more information than what `designspaceLib.processRules()` returns, so I would need either to modify what that function returns (is that alright? Do other libraries rely on the previous output? I guess yes) or introduce another functions that returns what I want.

@anthrotype what do you think? Sorry for the long explanation!