### PR TITLE
Don't generate GDEF when already in Glyphs file

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -16,6 +16,7 @@ import glob
 import logging
 import math
 import os
+import re
 import shutil
 import tempfile
 from collections import OrderedDict
@@ -164,12 +165,20 @@ class FontProject:
             instance_dir = os.path.relpath(instance_dir, designspace_dir)
             assert not os.path.isabs(instance_dir)
 
+        # https://github.com/googlefonts/fontmake/issues/702
+        generate_GDEF = True
+        for fea in font.featurePrefixes:
+            if re.search(r"^\s*table\s+GDEF\s+{", fea.code, flags=re.MULTILINE):
+                generate_GDEF = False
+                break
+
         designspace = glyphsLib.to_designspace(
             font,
             family_name=family_name,
             instance_dir=instance_dir,
             write_skipexportglyphs=write_skipexportglyphs,
             ufo_module=ufoLib2,
+            generate_GDEF=generate_GDEF,
         )
 
         masters = {}

--- a/tests/data/GDEFPresent.glyphs
+++ b/tests/data/GDEFPresent.glyphs
@@ -1,0 +1,133 @@
+{
+.appVersion = "1354";
+classes = (
+{
+automatic = 1;
+code = A;
+name = Uppercase;
+}
+);
+customParameters = (
+{
+name = "Use Line Breaks";
+value = 1;
+}
+);
+date = "2021-02-25 11:04:52 +0000";
+familyName = GDEFPresent;
+featurePrefixes = (
+{
+code = "table GDEF {
+  GlyphClassDef [A], , , ;
+} GDEF;
+";
+name = Prefix;
+}
+);
+features = (
+{
+automatic = 1;
+code = "pos @Uppercase <5 0 10 0>;
+";
+name = cpsp;
+}
+);
+fontMaster = (
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "A82E8779-E9D6-4341-BA1A-AF1FA001C07D";
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = A;
+lastChange = "2021-02-25 11:11:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top;
+position = "{300, 700}";
+}
+);
+layerId = "A82E8779-E9D6-4341-BA1A-AF1FA001C07D";
+paths = (
+{
+closed = 1;
+nodes = (
+"60 0 LINE",
+"540 0 LINE",
+"540 700 LINE",
+"60 700 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0041;
+},
+{
+glyphname = B;
+lastChange = "2021-02-25 11:20:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top;
+position = "{300, 700}";
+}
+);
+layerId = "A82E8779-E9D6-4341-BA1A-AF1FA001C07D";
+paths = (
+{
+closed = 1;
+nodes = (
+"60 0 LINE",
+"540 0 LINE",
+"540 700 LINE",
+"60 700 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0042;
+},
+{
+glyphname = acutecomb;
+lastChange = "2021-02-25 11:12:05 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{300, 621}";
+}
+);
+layerId = "A82E8779-E9D6-4341-BA1A-AF1FA001C07D";
+paths = (
+{
+closed = 1;
+nodes = (
+"60 621 LINE",
+"540 621 LINE",
+"540 700 LINE",
+"60 700 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0301;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -657,3 +657,28 @@ def test_static_otf_cffsubr_subroutinizer(data_dir, tmp_path):
     )
 
     assert {p.name for p in tmp_path.glob("*.otf")} == {"MyFont-Light.otf"}
+
+
+def test_GDEF_in_glyphs_features(data_dir, tmp_path):
+    shutil.copyfile(data_dir / "GDEFPresent.glyphs", tmp_path / "GDEFPresent.glyphs")
+
+    output_dir = tmp_path / "master_ttf"
+    fontmake.__main__.main(
+        [
+            "-g",
+            str(tmp_path / "GDEFPresent.glyphs"),
+            "--output-dir",
+            str(output_dir),
+            "-o",
+            "ttf",
+        ]
+    )
+
+    assert {p.name for p in output_dir.glob("*.*")} == {
+        "GDEFPresent-Regular.ttf",
+    }
+
+    test_output_ttf = fontTools.ttLib.TTFont(output_dir / "GDEFPresent-Regular.ttf")
+    assert "GDEF" in test_output_ttf
+    gdef = test_output_ttf["GDEF"].table
+    assert gdef.GlyphClassDef.classDefs == {"A": 1}


### PR DESCRIPTION
Fixes #702 [ValueError: The features already contain a `table GDEF {...}` statement](https://github.com/googlefonts/fontmake/issues/702).
Replaces #709 [ add "--no-generate-GDEF" command line parameter](https://github.com/googlefonts/fontmake/pull/709).