### PR TITLE
drop Python 3.6, require >= 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "pypy-3.7"]
+        python-version: [3.7, 3.8, 3.9, "pypy-3.7"]
         platform: [ubuntu-latest, windows-latest]
         exclude:
           - platform: windows-latest

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ binaries (.otf, .ttf).
 Installation
 ~~~~~~~~~~~~
 
-Fontmake requires Python 3.6 or later.
+Fontmake requires Python 3.7 or later.
 
 Releases are available on `PyPI`_ and can be installed with `pip`_.
 
@@ -71,6 +71,6 @@ process, via methods of the ``fontmake.font_project.FontProject`` class.
 .. _Github releases: https://github.com/googlefonts/fontmake/releases
 .. _pipx: https://github.com/pipxproject/pipx
 .. |GitHub Actions Build Status| image:: https://github.com/googlefonts/fontmake/workflows/Test%20+%20Deploy/badge.svg
-.. |Python Versions| image:: https://img.shields.io/badge/python-3.6-blue.svg
+.. |Python Versions| image:: https://img.shields.io/badge/python-3.7-blue.svg
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/fontmake.svg
    :target: https://pypi.org/project/fontmake/

--- a/build_pyz.sh
+++ b/build_pyz.sh
@@ -6,7 +6,7 @@ set -x
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 PLATFORMS=(manylinux1_x86_64 macosx_10_6_intel win32 win_amd64)
-PYTHON_VERSIONS=(3.6 3.7 3.8)
+PYTHON_VERSIONS=(3.7 3.8 3.9)
 FONTMAKE_VERSION="$(python setup.py --version)"
 
 FONTMAKE_WHEEL="${HERE}/dist/fontmake-${FONTMAKE_VERSION}-py3-none-any.whl"

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     package_dir={"": "Lib"},
     entry_points={"console_scripts": ["fontmake = fontmake.__main__:main"]},
     setup_requires=wheel + ["setuptools_scm"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "fonttools[ufo,lxml,unicode]>=4.21.1 ; platform_python_implementation == 'CPython'",
         "fonttools[ufo,unicode]>=4.21.1 ; platform_python_implementation != 'CPython'",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py3{6,7,8,9}, pypy3, coverage-report
+envlist = lint, py3{7,8,9}, pypy3, coverage-report
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
3.10 is out next week, while 3.6 reaches end of life by the end of this year.
It's time to require 3.7 or greater, so we can finally use built-in dataclasses and more.