### PR TITLE
Use glyphsLib minimal builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "pypy-3.7"]
+        python-version: [3.7, 3.8, 3.9] # "pypy-3.7", see #810
         platform: [ubuntu-latest, windows-latest]
         exclude:
           - platform: windows-latest

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -173,6 +173,8 @@ class FontProject:
             write_skipexportglyphs=write_skipexportglyphs,
             ufo_module=ufoLib2,
             generate_GDEF=generate_GDEF,
+            store_editor_state=False,
+            minimal=True,
         )
 
         masters = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-fonttools[unicode,ufo,lxml]==4.22.0 ; platform_python_implementation == 'CPython'
-fonttools[unicode,ufo]==4.22.0 ; platform_python_implementation != 'CPython'
+fonttools[unicode,ufo,lxml]==4.27.1 ; platform_python_implementation == 'CPython'
+fonttools[unicode,ufo]==4.27.1 ; platform_python_implementation != 'CPython'
 cu2qu==1.6.7.post1
-glyphsLib==5.3.2
+glyphsLib==6.0.0b3
 ufo2ft[pathops]==2.21.0
 MutatorMath==3.0.1
 fontMath==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         "fonttools[ufo,lxml,unicode]>=4.21.1 ; platform_python_implementation == 'CPython'",
         "fonttools[ufo,unicode]>=4.21.1 ; platform_python_implementation != 'CPython'",
-        "glyphsLib>=5.3.2",
+        "glyphsLib>=6.0.0b3",
         "ufo2ft[compreffor]>=2.20.0",
         "fontMath>=0.6.0",
         "ufoLib2>=0.8.0",


### PR DESCRIPTION
This tells glyphsLib to create enough UFO for building binary fonts and discard any unneeded data.

This requires glyphsLib 6.0.0 or later.