### PR TITLE
Compatibility checker: Sort anchor set before checking for equality

### DIFF
--- a/Lib/fontmake/compatibility.py
+++ b/Lib/fontmake/compatibility.py
@@ -42,7 +42,7 @@ class CompatibilityChecker:
 
         anchors = [g.anchors for g in glyphs]
         self.ensure_all_same(
-            lambda anchors: '"' + (", ".join(a.name for a in anchors)) + '"',
+            lambda anchors: '"' + (", ".join(sorted(a.name for a in anchors))) + '"',
             anchors,
             "anchors",
         )


### PR DESCRIPTION
Compare anchors by sorted name, not just name; fixes issue mentioned in https://github.com/googlefonts/fontmake/pull/832#issuecomment-1007290979