### PR TITLE
add support for ttfautohint-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ ufoLib2==0.13.0
 attrs==21.4.0
 cffsubr==0.2.9.post1
 compreffor==0.5.1.post1
+ttfautohint-py==0.4.3.post1

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ extras_require = {
         # "lxml>=4.2.4",
     ],
     "mutatormath": ["MutatorMath>=2.1.2"],
+    "autohint": ["ttfautohint-py>=0.4.3"],
 }
 # use a special 'all' key as shorthand to includes all the extra dependencies
 extras_require["all"] = sum(extras_require.values(), [])


### PR DESCRIPTION
The ttfautohint-py python wrapper does not come with a `ttfautohint` script, to avoid shadowing the original ttfautohint (c++) executable. But one can still call it from the command line or as a subprocess with `python -m ttfautohint`. This PR does that instead of importing ttfautohint and using its Python API, to avoid make too broad changes and continue to support the standalone ttfautohint command.

Fixes https://github.com/googlefonts/fontmake/issues/562

Required for #850  /cc @yanone