### PR TITLE
CompatibilityChecker: make large error messages more concise

### DIFF
--- a/Lib/fontmake/compatibility.py
+++ b/Lib/fontmake/compatibility.py
@@ -69,9 +69,13 @@ class CompatibilityChecker:
             logger.debug(f"All fonts had same {what} in {context}")
             return True
         logger.error(f"Fonts had differing {what} in {context}:")
+        debug_enabled = logger.isEnabledFor(logging.DEBUG)
         for value, fonts in values.items():
-            fontlist = ", ".join(fonts)
-            logger.error(f" * {fontlist} had {value}")
+            if debug_enabled or len(fonts) <= 6:
+                key = ", ".join(fonts)
+            else:
+                key = f"{len(fonts)} fonts"
+            logger.error(f" * {key} had {value}")
         self.okay = False
         return False
 


### PR DESCRIPTION
If there's more than 6 fonts, only show the font count.

Before

```
Fonts had differing anchors in glyph A:
 * RobotoFlex GRAD-200 had "bottom, ogonek"
 * RobotoFlex GRAD150, RobotoFlex opsz144, RobotoFlex opsz8, 
RobotoFlex wdth151, RobotoFlex wdth25, RobotoFlex wght100, 
RobotoFlex wght 1000, RobotoFlex Regular had "bottom, ogonek, top"
```

After

```
Fonts had differing anchors in glyph A:
 * RobotoFlex GRAD-200 had "bottom, ogonek"
 * 8 fonts had "bottom, ogonek, top"
```

Fixes #854 