### PR TITLE
Add option to disable ttfautohint even if source has 'TTFAutohint options'

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -373,7 +373,7 @@ def main(args=None):
         const=True,  # without args means run ttfautohint with default options
         help="Run ttfautohint. Can provide arguments, quoted. By default, ttfautohint "
         "is run if the (.glyphs) source contains a 'TTFAutohint options' instance "
-        "custom parameter. This option overrides that. See --no-autohint to disable."
+        "custom parameter. This option overrides that. See --no-autohint to disable.",
     )
     contourGroup.add_argument(
         "-A",

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -370,8 +370,18 @@ def main(args=None):
         "-a",
         "--autohint",
         nargs="?",
-        const="",
-        help="Run ttfautohint. Can provide arguments, quoted",
+        const=True,  # without args means run ttfautohint with default options
+        help="Run ttfautohint. Can provide arguments, quoted. By default, ttfautohint "
+        "is run if the (.glyphs) source contains a 'TTFAutohint options' instance "
+        "custom parameter. This option overrides that. See --no-autohint to disable."
+    )
+    contourGroup.add_argument(
+        "-A",
+        "--no-autohint",
+        dest="autohint",
+        action="store_false",
+        help="Do not run ttfautohint, even if source contains a 'TTFAutohint options' "
+        "custom parameter",
     )
     contourGroup.add_argument(
         "--cff-round-tolerance",

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -430,10 +430,13 @@ class FontProject:
             ufos: Font objects to compile.
             ttf: If True, build fonts with TrueType outlines and .ttf extension.
             is_instance: If output fonts are instances, for generating paths.
-            autohint: Parameters to provide to ttfautohint. If not provided, the
-                UFO lib is scanned for autohinting parameters. If nothing is found,
-                the autohinting step is skipped. The lib key is
-                "com.schriftgestaltung.customParameter.InstanceDescriptorAsGSInstance.TTFAutohint options"
+            autohint (Union[bool, None, str]): Parameters to provide to ttfautohint.
+                If set to None (default), the UFO lib is scanned for autohinting parameters.
+                If nothing is found, the autohinting step is skipped. The lib key is
+                "com.schriftgestaltung.customParameter.InstanceDescriptorAsGSInstance.TTFAutohint options".
+                If set to False, then no autohinting takes place whether or not the
+                source specifies 'TTFAutohint options'. If True, it runs ttfautohint
+                with no additional options.
             subset: Whether to subset the output according to data in the UFOs.
                 If not provided, also determined by flags in the UFOs.
             use_production_names: Whether to use production glyph names in the
@@ -548,7 +551,11 @@ class FontProject:
             # Decide on autohinting and its parameters
             autohint_thisfont = (
                 (
-                    autohint
+                    None
+                    if autohint is False
+                    else ""  # use default options if autohint=True
+                    if autohint is True
+                    else autohint
                     if autohint is not None
                     else ufo.lib.get(AUTOHINTING_PARAMETERS)
                 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -725,6 +725,8 @@ def test_main_with_filter(data_dir, tmp_path):
         (),
         ("-a",),
         ("--autohint", "-D latn"),
+        ("-A",),
+        ("--no-autohint",),
     ],
 )
 def test_autohinting(data_dir, tmp_path, autohint_options):
@@ -750,4 +752,8 @@ def test_autohinting(data_dir, tmp_path, autohint_options):
     test_output_ttf = fontTools.ttLib.TTFont(
         tmp_path / "PadyakkeExpandedOne-Regular.ttf"
     )
-    assert "fpgm" in test_output_ttf
+
+    if not {"-A", "--no-autohint"}.intersection(autohint_options):
+        assert "fpgm" in test_output_ttf  # hinted
+    else:
+        assert "fpgm" not in test_output_ttf  # unhinted


### PR DESCRIPTION
Fixes https://github.com/googlefonts/fontmake/issues/866