### PR TITLE
Allow disabling the compatibility checker

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -335,7 +335,8 @@ def main(args=None):
         help="Enable ufoLib validation on reading/writing UFO files. It is "
         "disabled by default",
     )
-    outputGroup.add_argument(
+    compatibilityGroup = outputGroup.add_mutually_exclusive_group()
+    compatibilityGroup.add_argument(
         "--check-compatibility",
         action="store_true",
         help="Check if the source files are interpolatable. It is "
@@ -343,6 +344,13 @@ def main(args=None):
         "or what the 'Enforce Compatibility Check' custom parameter is "
         "set on a Glyphs file",
     )
+    compatibilityGroup.add_argument(
+        "--no-check-compatibility",
+        action="store_true",
+        dest="disable_compatibility_check",
+        help="Turns off the compatibility checker even when building variable fonts",
+    )
+
     outputGroup.add_argument(
         "--expand-features-to-instances",
         action="store_true",
@@ -638,6 +646,7 @@ def main(args=None):
                 "round_instances",
                 "expand_features_to_instances",
                 "check_compatibility",
+                "disable_compatibility_check",
             ],
             inputs.format_name,
         )

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -339,6 +339,7 @@ def main(args=None):
     compatibilityGroup.add_argument(
         "--check-compatibility",
         action="store_true",
+        default=None,
         help="Check if the source files are interpolatable. It is "
         "disabled by default, but enabled when building variable fonts "
         "or what the 'Enforce Compatibility Check' custom parameter is "
@@ -347,6 +348,7 @@ def main(args=None):
     compatibilityGroup.add_argument(
         "--no-check-compatibility",
         action="store_false",
+        default=None,
         dest="check_compatibility",
         help="Turns off the compatibility checker even when building variable fonts",
     )

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -346,8 +346,8 @@ def main(args=None):
     )
     compatibilityGroup.add_argument(
         "--no-check-compatibility",
-        action="store_true",
-        dest="disable_compatibility_check",
+        action="store_false",
+        dest="check_compatibility",
         help="Turns off the compatibility checker even when building variable fonts",
     )
 
@@ -646,7 +646,6 @@ def main(args=None):
                 "round_instances",
                 "expand_features_to_instances",
                 "check_compatibility",
-                "disable_compatibility_check",
             ],
             inputs.format_name,
         )

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -959,8 +959,7 @@ class FontProject:
         filters=None,
         expand_features_to_instances=False,
         use_mutatormath=False,
-        check_compatibility=False,
-        disable_compatibility_check=False,
+        check_compatibility=None,
         **kwargs,
     ):
         """Run toolchain from a DesignSpace document to produce either static
@@ -1032,7 +1031,7 @@ class FontProject:
             explicit_check = any(
                 font.lib.get(COMPAT_CHECK_KEY, False) for font in source_fonts
             )
-            if not disable_compatibility_check and (interp_outputs or check_compatibility or explicit_check):
+            if check_compatibility is not False and (interp_outputs or check_compatibility or explicit_check):
                 if not CompatibilityChecker(source_fonts).check():
                     message = "Compatibility check failed"
                     if discrete_location:

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -960,6 +960,7 @@ class FontProject:
         expand_features_to_instances=False,
         use_mutatormath=False,
         check_compatibility=False,
+        disable_compatibility_check=False,
         **kwargs,
     ):
         """Run toolchain from a DesignSpace document to produce either static
@@ -1031,7 +1032,7 @@ class FontProject:
             explicit_check = any(
                 font.lib.get(COMPAT_CHECK_KEY, False) for font in source_fonts
             )
-            if interp_outputs or check_compatibility or explicit_check:
+            if not disable_compatibility_check and (interp_outputs or check_compatibility or explicit_check):
                 if not CompatibilityChecker(source_fonts).check():
                     message = "Compatibility check failed"
                     if discrete_location:

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -1031,7 +1031,9 @@ class FontProject:
             explicit_check = any(
                 font.lib.get(COMPAT_CHECK_KEY, False) for font in source_fonts
             )
-            if check_compatibility is not False and (interp_outputs or check_compatibility or explicit_check):
+            if check_compatibility is not False and (
+                interp_outputs or check_compatibility or explicit_check
+            ):
                 if not CompatibilityChecker(source_fonts).check():
                     message = "Compatibility check failed"
                     if discrete_location:

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,7 +1,10 @@
+import pytest
 import ufoLib2
 from fontTools import designspaceLib
 
 from fontmake.compatibility import CompatibilityChecker
+from fontmake.__main__ import main
+from fontmake.errors import FontmakeError
 
 
 def test_compatibility_checker(data_dir, caplog):
@@ -24,3 +27,22 @@ def test_compatibility_checker(data_dir, caplog):
     assert (
         "Fonts had differing point type in glyph D, contour 0, point 10" in caplog.text
     )
+
+def test_compatibility_cli(data_dir, caplog):
+    ds = str(data_dir / "IncompatibleSans" / "IncompatibleSans.designspace")
+    with pytest.raises(SystemExit) as e_info:
+        main(["-o", "variable", "-m", ds])
+
+    main(["-o", "ttf", "-m", ds])
+
+    with pytest.raises(SystemExit) as e_info:
+        main(["--check-compatibility", "-o", "ttf", "-m", ds])
+
+    # We stopped things before they got to the cu2qu level
+    assert "cu2qu.ufo" not in caplog.text
+
+    with pytest.raises(SystemExit):
+        main(["--no-check-compatibility", "-o", "variable", "-m", ds])
+
+    # Things got to the cu2qu level (i.e. compatibility checker did not run)
+    assert "cu2qu.ufo" in caplog.text

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -2,8 +2,8 @@ import pytest
 import ufoLib2
 from fontTools import designspaceLib
 
-from fontmake.compatibility import CompatibilityChecker
 from fontmake.__main__ import main
+from fontmake.compatibility import CompatibilityChecker
 from fontmake.errors import FontmakeError
 
 

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -4,7 +4,6 @@ from fontTools import designspaceLib
 
 from fontmake.__main__ import main
 from fontmake.compatibility import CompatibilityChecker
-from fontmake.errors import FontmakeError
 
 
 def test_compatibility_checker(data_dir, caplog):
@@ -31,12 +30,12 @@ def test_compatibility_checker(data_dir, caplog):
 
 def test_compatibility_cli(data_dir, caplog):
     ds = str(data_dir / "IncompatibleSans" / "IncompatibleSans.designspace")
-    with pytest.raises(SystemExit) as e_info:
+    with pytest.raises(SystemExit):
         main(["-o", "variable", "-m", ds])
 
     main(["-o", "ttf", "-m", ds])
 
-    with pytest.raises(SystemExit) as e_info:
+    with pytest.raises(SystemExit):
         main(["--check-compatibility", "-o", "ttf", "-m", ds])
 
     # We stopped things before they got to the cu2qu level

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -28,6 +28,7 @@ def test_compatibility_checker(data_dir, caplog):
         "Fonts had differing point type in glyph D, contour 0, point 10" in caplog.text
     )
 
+
 def test_compatibility_cli(data_dir, caplog):
     ds = str(data_dir / "IncompatibleSans" / "IncompatibleSans.designspace")
     with pytest.raises(SystemExit) as e_info:


### PR DESCRIPTION
The compatibility checker is really nice for reporting errors but it's actually pretty heavy to run on fonts where we already have built it before and know things are OK. This saves a few seconds.