### PR TITLE
clean up logging configuration

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -194,6 +194,7 @@ def _configure_logging(level=None, timing=False):
         # timing-related DEBUG messages get a separate configuration so we
         # can enable them without needing to lower the global verbosity level
         configLogger(logger="fontmake.timer", level=logging.DEBUG, format=fmt)
+        configLogger(logger="ufo2ft.timer", level=logging.DEBUG, format=fmt)
 
 
 def main(args=None):

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -32,7 +32,7 @@ import ufo2ft.errors
 import ufoLib2
 from fontTools import designspaceLib
 from fontTools.designspaceLib.split import splitInterpolable
-from fontTools.misc.loggingTools import Timer, configLogger
+from fontTools.misc.loggingTools import Timer
 from fontTools.misc.plistlib import load as readPlist
 from fontTools.ttLib import TTFont
 from fontTools.varLib.interpolate_layout import interpolate_layout
@@ -115,11 +115,29 @@ def temporarily_disabling_axis_maps(designspace_path):
 class FontProject:
     """Provides methods for building fonts."""
 
-    def __init__(self, timing=False, verbose="INFO", validate_ufo=False):
-        logging.basicConfig(level=getattr(logging, verbose.upper()))
-        logging.getLogger("fontTools.subset").setLevel(logging.WARNING)
-        if timing:
-            configLogger(logger=timer.logger, level=logging.DEBUG)
+    def __init__(
+        self,
+        timing=None,  # deprecated
+        verbose=None,  # deprecated
+        validate_ufo=False,
+    ):
+        if verbose is not None or timing is not None:
+            from warnings import warn
+
+            from fontmake.__main__ import _configure_logging
+
+            warn(
+                "The 'verbose'/'timing' arguments are deprecated. "
+                "Logging configuration is global and should not be "
+                "specified in the FontProject constructor. "
+                "Use the logging API to configure fontmake's loggers "
+                "for your application. E.g. fontmake main() function "
+                "uses logging.basicConfig().",
+                UserWarning,
+                stacklevel=2,
+            )
+
+            _configure_logging(verbose, timing)
 
         logger.debug(
             "ufoLib UFO validation is %s", "enabled" if validate_ufo else "disabled"


### PR DESCRIPTION
logging configuration is global, does not belong to a specific `fontmake.FontProject` instance, so it should only be done inside `main()`. This PR deprecates the `verbose` and `timing` parameters to FontProject constructor and moves the logging configuration to the CLI module (`fontmake.__main__`).
The old parameter continue to work but a deprecation warning is issued (category is actually `UserWarning` as `DeprecationWarning` proper are usually muted -- just to shout it out more louder)

It also enables logging configuration for a logger named "ufo2ft.timer" (which reports timing info inside ufo2ft) which doesn't exist yet but will soon (https://github.com/googlefonts/ufo2ft/pull/641)
This and fontmake's own timing logger are controlled by the fontmake `--timing` flag, independently from the `--verbose LEVEL` flag which control the root logger configuration.