### PR TITLE
Update glyphsLib to gain support for glyphspackage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fonttools[unicode,lxml,ufo]==4.34.0; platform_python_implementation == 'CPython'
 fonttools[unicode,ufo]==4.34.0; platform_python_implementation != 'CPython'
 cu2qu==1.6.7.post1
-glyphsLib==6.0.6
+glyphsLib==6.1.0
 ufo2ft==2.28.0
 MutatorMath==3.0.1
 fontMath==0.9.1


### PR DESCRIPTION
[glyphsLib v6.1.0](https://github.com/googlefonts/glyphsLib/releases/tag/v6.1.0) adds support for loading .glyphspackage sources. Updating it for fontmake would broaden the use of fontmake and remove the need for preprocessing steps with e.g. [glyphspkg](https://github.com/jenskutilek/glyphspkg)