### PR TITLE
Use MathGlyph's "strict" flag

### DIFF
--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -603,7 +603,7 @@ def collect_glyph_masters(
             source.location, axis_bounds
         )
         locations_and_masters.append(
-            (normalized_location, fontMath.MathGlyph(source_glyph))
+            (normalized_location, fontMath.MathGlyph(source_glyph, strict=True))
         )
 
     # Filter out empty glyphs if the default glyph is not empty.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cu2qu==1.6.7.post1
 glyphsLib==6.1.0
 ufo2ft==2.29.0
 MutatorMath==3.0.1
-fontMath==0.9.2
+fontMath==0.9.3
 defcon[lxml]==0.10.2; platform_python_implementation == 'CPython'
 defcon==0.10.2; platform_python_implementation != 'CPython'
 booleanOperations==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "fonttools[ufo,unicode]>=4.38.0 ; implementation_name != 'cpython'",
         "glyphsLib>=6.1.0",
         "ufo2ft[compreffor]>=2.29.0",
-        "fontMath>=0.9.1",
+        "fontMath>=0.9.3",
         "ufoLib2>=0.13.0",
         "attrs>=19",
     ],

--- a/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/fontinfo.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/fontinfo.plist
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>750</integer>
+    <key>capHeight</key>
+    <integer>750</integer>
+    <key>descender</key>
+    <integer>-250</integer>
+    <key>familyName</key>
+    <string>Test Ufo</string>
+    <key>guidelines</key>
+    <array/>
+    <key>postscriptBlueValues</key>
+    <array/>
+    <key>postscriptFamilyBlues</key>
+    <array/>
+    <key>postscriptFamilyOtherBlues</key>
+    <array/>
+    <key>postscriptOtherBlues</key>
+    <array/>
+    <key>postscriptStemSnapH</key>
+    <array/>
+    <key>postscriptStemSnapV</key>
+    <array/>
+    <key>styleName</key>
+    <string>Bold</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+  </dict>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/glyphs/contents.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/glyphs/contents.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>test</key>
+    <string>test.glif</string>
+  </dict>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/glyphs/layerinfo.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>color</key>
+    <string>1,0.75,0,0.7</string>
+  </dict>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/glyphs/test.glif
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/glyphs/test.glif
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="test" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="19" y="17" type="curve"/>
+      <point x="481" y="17" type="line"/>
+      <point x="481.0" y="17.0"/>
+      <point x="481.0" y="17.0"/>
+      <point x="481" y="17" type="curve"/>
+      <point x="481" y="479" type="line"/>
+      <point x="481.0" y="479.0"/>
+      <point x="481.0" y="479.0"/>
+      <point x="481" y="479" type="curve"/>
+      <point x="19" y="479" type="line"/>
+      <point x="19.0" y="479.0"/>
+      <point x="19.0" y="479.0"/>
+      <point x="19" y="479" type="curve"/>
+      <point x="19" y="17" type="line"/>
+      <point x="19.0" y="17.0"/>
+      <point x="19.0" y="17.0"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/layercontents.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>foreground</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/lib.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/lib.plist
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.typemytype.robofont.compileSettings.autohint</key>
+    <true/>
+    <key>com.typemytype.robofont.compileSettings.checkOutlines</key>
+    <false/>
+    <key>com.typemytype.robofont.compileSettings.createDummyDSIG</key>
+    <true/>
+    <key>com.typemytype.robofont.compileSettings.decompose</key>
+    <false/>
+    <key>com.typemytype.robofont.compileSettings.generateFormat</key>
+    <integer>0</integer>
+    <key>com.typemytype.robofont.compileSettings.releaseMode</key>
+    <false/>
+    <key>com.typemytype.robofont.italicSlantOffset</key>
+    <integer>0</integer>
+    <key>com.typemytype.robofont.segmentType</key>
+    <string>curve</string>
+    <key>com.typemytype.robofont.shouldAddPointsInSplineConversion</key>
+    <integer>1</integer>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>test</string>
+    </array>
+  </dict>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/metainfo.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareOne.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/fontinfo.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/fontinfo.plist
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>750</integer>
+    <key>capHeight</key>
+    <integer>750</integer>
+    <key>descender</key>
+    <integer>-250</integer>
+    <key>familyName</key>
+    <string>Test Ufo</string>
+    <key>guidelines</key>
+    <array/>
+    <key>postscriptBlueValues</key>
+    <array/>
+    <key>postscriptFamilyBlues</key>
+    <array/>
+    <key>postscriptFamilyOtherBlues</key>
+    <array/>
+    <key>postscriptOtherBlues</key>
+    <array/>
+    <key>postscriptStemSnapH</key>
+    <array/>
+    <key>postscriptStemSnapV</key>
+    <array/>
+    <key>styleName</key>
+    <string>Regular</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+  </dict>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/glyphs/contents.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/glyphs/contents.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>test</key>
+    <string>test.glif</string>
+  </dict>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/glyphs/layerinfo.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>color</key>
+    <string>1,0.75,0,0.7</string>
+  </dict>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/glyphs/test.glif
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/glyphs/test.glif
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="test" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="219" y="217" type="curve"/>
+      <point x="281" y="217" type="line"/>
+      <point x="281.0" y="217.0"/>
+      <point x="281.0" y="217.0"/>
+      <point x="281" y="217" type="curve"/>
+      <point x="281" y="279" type="line"/>
+      <point x="281.0" y="279.0"/>
+      <point x="281.0" y="279.0"/>
+      <point x="281" y="279" type="curve"/>
+      <point x="219" y="279" type="line"/>
+      <point x="219.0" y="279.0"/>
+      <point x="219.0" y="279.0"/>
+      <point x="219" y="279" type="curve"/>
+      <point x="219" y="217" type="line"/>
+      <point x="219.0" y="217.0"/>
+      <point x="219.0" y="217.0"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/layercontents.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>foreground</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/lib.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/lib.plist
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.typemytype.robofont.compileSettings.autohint</key>
+    <true/>
+    <key>com.typemytype.robofont.compileSettings.checkOutlines</key>
+    <false/>
+    <key>com.typemytype.robofont.compileSettings.createDummyDSIG</key>
+    <true/>
+    <key>com.typemytype.robofont.compileSettings.decompose</key>
+    <false/>
+    <key>com.typemytype.robofont.compileSettings.generateFormat</key>
+    <integer>0</integer>
+    <key>com.typemytype.robofont.compileSettings.releaseMode</key>
+    <false/>
+    <key>com.typemytype.robofont.italicSlantOffset</key>
+    <integer>0</integer>
+    <key>com.typemytype.robofont.segmentType</key>
+    <string>curve</string>
+    <key>com.typemytype.robofont.shouldAddPointsInSplineConversion</key>
+    <integer>1</integer>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>test</string>
+    </array>
+  </dict>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/metainfo.plist
+++ b/tests/data/InstantiatorStrictMathGlyph/SquareTwo.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/tests/data/InstantiatorStrictMathGlyph/StrictMathGlyph.designspace
+++ b/tests/data/InstantiatorStrictMathGlyph/StrictMathGlyph.designspace
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="100" maximum="1000" default="100"/>
+  </axes>
+  <sources>
+    <source filename="SquareOne.ufo" familyname="InstatiatorStrictMathGlyph" stylename="Regular">
+      <location>
+        <dimension name="Weight" xvalue="100"/>
+      </location>
+    </source>
+    <source filename="SquareTwo.ufo" familyname="InstatiatorStrictMathGlyph" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="1000"/>
+      </location>
+    </source>
+  </sources>
+
+  <instances>
+    <instance filename="SquareIntermediate.ufo" familyname="InstatiatorStrictMathGlyph" stylename="Medium">
+      <location>
+        <dimension name="Weight" xvalue="500"/>
+      </location>
+    </instance>
+  </instances>
+</designspace>

--- a/tests/test_instantiator.py
+++ b/tests/test_instantiator.py
@@ -656,3 +656,17 @@ def test_designspace_v5_discrete_axis_raises_error(data_dir):
         fontmake.instantiator.InstantiatorError, match="splitInterpolable"
     ):
         fontmake.instantiator.Instantiator.from_designspace(designspace)
+
+
+def test_strict_math_glyph(data_dir):
+    designspace = designspaceLib.DesignSpaceDocument.fromfile(
+        data_dir / "InstantiatorStrictMathGlyph" / "StrictMathGlyph.designspace"
+    )
+    generator = fontmake.instantiator.Instantiator.from_designspace(
+        designspace, round_geometry=True
+    )
+    fonts = [generator.generate_instance(instance) for instance in designspace.instances]
+    assert len(fonts) == 1
+    glyph = fonts[0]["test"]
+    assert len(glyph.contours) == 1
+    assert len(glyph.contours[0].points) == 16

--- a/tests/test_instantiator.py
+++ b/tests/test_instantiator.py
@@ -665,7 +665,9 @@ def test_strict_math_glyph(data_dir):
     generator = fontmake.instantiator.Instantiator.from_designspace(
         designspace, round_geometry=True
     )
-    fonts = [generator.generate_instance(instance) for instance in designspace.instances]
+    fonts = [
+        generator.generate_instance(instance) for instance in designspace.instances
+    ]
     assert len(fonts) == 1
     glyph = fonts[0]["test"]
     assert len(glyph.contours) == 1


### PR DESCRIPTION
This fixes #961, and makes instantiator.py as strict as varLib when interpolating.

Depends on https://github.com/robotools/fontMath/pull/305, though, as fontMath doesn't properly propagate its "strict" flag down to copies.

So this PR should probably also update its fontMath version dependency, once a new fontMath is out.