### PR TITLE
Instantiator support for non-default layer sources

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -137,7 +137,7 @@ def parse_mutually_exclusive_inputs(parser, args):
         ):
             ufo_paths.append(filename)
         else:
-            parser.error("Unknown input file extension: {!r}".format(filename))
+            parser.error(f"Unknown input file extension: {filename!r}")
 
     count = sum(bool(p) for p in (glyphs_path, ufo_paths, designspace_path))
     if count == 0:

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -137,7 +137,7 @@ def parse_mutually_exclusive_inputs(parser, args):
         ):
             ufo_paths.append(filename)
         else:
-            parser.error(f"Unknown input file extension: '{filename}'")
+            parser.error("Unknown input file extension: {!r}".format(filename))
 
     count = sum(bool(p) for p in (glyphs_path, ufo_paths, designspace_path))
     if count == 0:

--- a/Lib/fontmake/errors.py
+++ b/Lib/fontmake/errors.py
@@ -26,7 +26,7 @@ class FontmakeError(Exception):
 
     def __str__(self):
         trail = " -> ".join(
-            "{!r}".format(f"{str(_try_relative_path(s))}")
+            f"{str(_try_relative_path(s))!r}"
             for s in reversed(self.source_trail)
             if s is not None
         )

--- a/Lib/fontmake/errors.py
+++ b/Lib/fontmake/errors.py
@@ -26,7 +26,7 @@ class FontmakeError(Exception):
 
     def __str__(self):
         trail = " -> ".join(
-            f"'{str(_try_relative_path(s))}'"
+            "{!r}".format(f"{str(_try_relative_path(s))}")
             for s in reversed(self.source_trail)
             if s is not None
         )

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -574,6 +574,7 @@ class FontProject:
             warnings.warn(
                 "the 'subroutinize' argument is deprecated, use 'optimize_cff'",
                 UserWarning,
+                stacklevel=2,
             )
             if subroutinize:
                 optimize_cff = CFFOptimization.SUBROUTINIZE
@@ -909,13 +910,15 @@ class FontProject:
                 if include is not None and not fullmatch(include, instance.name):
                     continue
 
-                logger.info(f'Generating instance UFO for "{instance.name}"')
+                logger.info("Generating instance UFO for {!r}".format(instance.name))
 
                 try:
                     instance.font = generator.generate_instance(instance)
                 except instantiator.InstantiatorError as e:
                     raise FontmakeError(
-                        f"Interpolating instance '{instance.styleName}' failed.",
+                        "Interpolating instance {!r} failed.".format(
+                            instance.styleName
+                        ),
                         designspace.path,
                     ) from e
 

--- a/Lib/fontmake/instantiator.py
+++ b/Lib/fontmake/instantiator.py
@@ -293,7 +293,7 @@ class Instantiator:
                 glyph_mutators[glyph_name] = Variator.from_masters(items, axis_order)
             except varLib.errors.VarLibError as e:
                 raise InstantiatorError(
-                    f"Cannot set up glyph '{glyph_name}' for interpolation: {e}'"
+                    f"Cannot set up glyph {glyph_name} for interpolation: {e}'"
                 ) from e
             glyph_name_to_unicodes[glyph_name] = default_font[glyph_name].unicodes
 
@@ -396,7 +396,7 @@ class Instantiator:
                 # whatever reason (usually outline incompatibility)...
                 if glyph_name not in self.skip_export_glyphs:
                     raise InstantiatorError(
-                        f"Failed to generate instance of glyph '{glyph_name}': "
+                        f"Failed to generate instance of glyph {glyph_name}: "
                         f"{str(e)}. (Note: the most common cause for an error here is "
                         "that the glyph outlines are not point-for-point compatible or "
                         "have the same starting point or are in the same order in all "
@@ -508,9 +508,9 @@ def _error_msg_no_default(designspace: designspaceLib.DesignSpaceDocument) -> st
 
     return (
         "Can't generate UFOs from this Designspace because there is no default "
-        f"master source at location '{default_location}'. Check that all 'default' "
+        "master source at location {!r}. Check that all 'default' "
         "values of all axes together point to a single actual master source. "
-        f"{bonus_msg}"
+        "{!s}".format(default_location, bonus_msg)
     )
 
 
@@ -683,8 +683,9 @@ def swap_glyph_names(font: ufoLib2.Font, name_old: str, name_new: str):
 
     if name_old not in font or name_new not in font:
         raise InstantiatorError(
-            f"Cannot swap glyphs '{name_old}' and '{name_new}', as either or both are "
-            "missing."
+            "Cannot swap glyphs {!r} and {!r}, as either or both are missing".format(
+                name_old, name_new
+            )
         )
 
     # 1. Swap outlines and glyph width. Ignore lib content and other properties.

--- a/tests/data/MutatorSans/MutatorSans-non-default-layer.designspace
+++ b/tests/data/MutatorSans/MutatorSans-non-default-layer.designspace
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.0">
+  <axes>
+    <axis tag="wdth" name="width" minimum="0" maximum="1000" default="0"/>
+    <axis tag="wght" name="weight" minimum="0" maximum="1000" default="0"/>
+  </axes>
+  <sources>
+    <source filename="MutatorSansLightCondensed.ufo" name="master.MutatorMathTest.LightCondensed.0" familyname="MutatorMathTest" stylename="LightCondensed" layer="support">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="weight" xvalue="0"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <instance familyname="MutatorMathTest" stylename="LightCondensed" filename="instances/MutatorMathTest-LightCondensed.ufo" postscriptfontname="MutatorMathTest-LightCondensed">
+      <location>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="weight" xvalue="0"/>
+      </location>
+      <kerning/>
+      <info/>
+    </instance>
+  </instances>
+</designspace>

--- a/tests/test_instantiator.py
+++ b/tests/test_instantiator.py
@@ -420,6 +420,18 @@ def test_interpolation_masters_as_instances(data_dir):
     assert instance_font["l"].width == 280
 
 
+def test_non_default_layer(data_dir, caplog):
+    designspace = designspaceLib.DesignSpaceDocument.fromfile(
+        data_dir / "MutatorSans" / "MutatorSans-non-default-layer.designspace"
+    )
+    designspace.loadSourceFonts(ufoLib2.Font.open)
+    generator = fontmake.instantiator.Instantiator.from_designspace(
+        designspace, round_geometry=True
+    )
+    instance_font = generator.generate_instance(designspace.instances[0])
+    assert {g.name for g in instance_font} == {"A", "S", "W"}
+
+
 def test_instance_attributes(data_dir):
     designspace = designspaceLib.DesignSpaceDocument.fromfile(
         data_dir / "DesignspaceTest" / "DesignspaceTest-instance-attrs.designspace"


### PR DESCRIPTION
This PR adds the ability to build from non-default layers. If the default designspace source is set to a non-default layer, then its glyphset is used as reference for all the other sources—glyphs that are not on the layer are discarded. I believe this should also address issue #603