### PR TITLE
remove MutatorMath integration

### DIFF
--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -15,7 +15,7 @@
 import logging
 import os
 import sys
-from argparse import ArgumentParser, FileType
+from argparse import SUPPRESS, ArgumentParser, FileType
 from collections import namedtuple
 from contextlib import contextmanager
 from textwrap import dedent
@@ -308,6 +308,8 @@ def main(args=None):
         """
         ),
     )
+    # no longer show option in --help but keep to produce nice error message
+    outputGroup.add_argument("--use-mutatormath", action="store_true", help=SUPPRESS)
     outputGroup.add_argument(
         "-M",
         "--masters-as-instances",
@@ -611,6 +613,13 @@ def main(args=None):
     )
 
     args = vars(parser.parse_args(args))
+
+    use_mutatormath = args.pop("use_mutatormath")
+    if use_mutatormath:
+        parser.error(
+            "MutatorMath is no longer supported by fontmake. "
+            "Try to use ufoProcessor: https://github.com/LettError/ufoProcessor"
+        )
 
     level = args.pop("verbose")
     _configure_logging(level, timing=args.pop("timing"))

--- a/Lib/fontmake/__main__.py
+++ b/Lib/fontmake/__main__.py
@@ -288,7 +288,7 @@ def main(args=None):
         'match a given "name" attribute, you can pass as argument '
         "the full instance name or a regular expression. "
         'E.g.: -i "Noto Sans Bold"; or -i ".* UI Condensed". '
-        "(for Glyphs or MutatorMath sources only). ",
+        "(for Glyphs or DesignSpace sources only). ",
     )
     outputGroup.add_argument(
         "--variable-fonts",
@@ -306,14 +306,6 @@ def main(args=None):
             "MyFontVF_WeightOnly.ttf"; or --variable-fonts
             "MyFontVFItalic_.*.ttf".
         """
-        ),
-    )
-    outputGroup.add_argument(
-        "--use-mutatormath",
-        action="store_true",
-        help=(
-            "Use MutatorMath to generate instances (supports extrapolation and "
-            "anisotropic locations)."
         ),
     )
     outputGroup.add_argument(
@@ -536,7 +528,7 @@ def main(args=None):
         const=True,
         metavar="MASTER_DIR",
         help="Interpolate layout tables from compiled master binaries. "
-        "Requires Glyphs or MutatorMath source.",
+        "Requires Glyphs or DesignSpace source.",
     )
     layoutGroup.add_argument(
         "--feature-writer",
@@ -643,7 +635,6 @@ def main(args=None):
                 "interpolate",
                 "masters_as_instances",
                 "interpolate_binary_layout",
-                "use_mutatormath",
             ],
             "variable output",
         )
@@ -655,16 +646,6 @@ def main(args=None):
             "static output",
             positive=False,
         )
-
-    if args.get("use_mutatormath"):
-        for module in ("defcon", "mutatorMath"):
-            try:
-                __import__(module)
-            except ImportError:
-                parser.error(
-                    f"{module} module not found; reinstall fontmake with the "
-                    "[mutatormath] extra"
-                )
 
     PRINT_TRACEBACK = level == "DEBUG"
     try:
@@ -705,7 +686,6 @@ def main(args=None):
             [
                 "interpolate",
                 "variable_fonts",
-                "use_mutatormath",
                 "interpolate_binary_layout",
                 "round_instances",
                 "expand_features_to_instances",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,7 @@ fonttools[unicode,ufo,lxml]==4.41.1; platform_python_implementation == 'CPython'
 fonttools[unicode,ufo]==4.41.1; platform_python_implementation != 'CPython'
 glyphsLib==6.2.5
 ufo2ft==2.32.0
-MutatorMath==3.0.1
 fontMath==0.9.3
-defcon[lxml]==0.10.2; platform_python_implementation == 'CPython'
-defcon==0.10.2; platform_python_implementation != 'CPython'
 booleanOperations==0.9.0
 ufoLib2==0.16.0
 attrs==23.1.0

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ extras_require = {
     "lxml": [
         # "lxml>=4.2.4",
     ],
+    # MutatorMath is no longer supported but a dummy extras is kept below
+    # to avoid fontmake installation failing if requested
+    "mutatormath": [],
     "autohint": ["ttfautohint-py>=0.5.0"],
 }
 # use a special 'all' key as shorthand to includes all the extra dependencies

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ extras_require = {
     "lxml": [
         # "lxml>=4.2.4",
     ],
-    "mutatormath": ["MutatorMath>=2.1.2"],
     "autohint": ["ttfautohint-py>=0.5.0"],
 }
 # use a special 'all' key as shorthand to includes all the extra dependencies

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -71,57 +71,6 @@ def test_interpolation_designspace_5(data_dir, tmp_path):
     }
 
 
-def test_interpolation_mutatormath(data_dir, tmp_path):
-    shutil.copytree(data_dir / "DesignspaceTest", tmp_path / "sources")
-
-    fontmake.__main__.main(
-        [
-            "-m",
-            str(tmp_path / "sources" / "DesignspaceTest.designspace"),
-            "-i",
-            "--use-mutatormath",
-            "--output-dir",
-            str(tmp_path),
-        ]
-    )
-
-    assert {p.name for p in tmp_path.glob("*.*")} == {
-        "MyFont-Regular.ttf",
-        "MyFont-Regular.otf",
-    }
-
-    test_output_ttf = fontTools.ttLib.TTFont(tmp_path / "MyFont-Regular.ttf")
-    assert test_output_ttf["OS/2"].usWeightClass == 400
-    glyph = test_output_ttf["glyf"]["l"]
-    assert glyph.xMin == 50
-    assert glyph.xMax == 170
-
-    test_output_otf = fontTools.ttLib.TTFont(tmp_path / "MyFont-Regular.otf")
-    assert test_output_otf["OS/2"].usWeightClass == 400
-    glyph_set = test_output_otf.getGlyphSet()
-    charstrings = list(test_output_otf["CFF "].cff.values())[0].CharStrings
-    glyph = charstrings["l"]
-    x_min, _, x_max, _ = glyph.calcBounds(glyph_set)
-    assert x_min == 50
-    assert x_max == 170
-
-
-def test_interpolation_mutatormath_source_layer(data_dir, tmp_path):
-    shutil.copytree(data_dir / "MutatorSans", tmp_path / "layertest")
-
-    with pytest.raises(SystemExit, match="sources with 'layer'"):
-        fontmake.__main__.main(
-            [
-                "-m",
-                str(tmp_path / "layertest" / "MutatorSans.designspace"),
-                "-i",
-                "--use-mutatormath",
-                "--output-dir",
-                str(tmp_path),
-            ]
-        )
-
-
 def test_interpolation_and_masters_as_instances(data_dir, tmp_path):
     shutil.copytree(data_dir / "DesignspaceTest", tmp_path / "sources")
 


### PR DESCRIPTION
The designspace reading/writing capabilities of MutatorMath are no longer supported, and have been replaced my [ufoProcessor](https://github.com/LettError/ufoProcessor).
This PR drops support for generating static instance UFOs using MutatorMath. Users who wish to continue using MutatorMath-only anisotropic locations or extrapolation are advised to use ufoProcessor separately to generate their instance UFOs, and then use fontmake to compile them to TTF/OTF.

Fixes #834 