### PR TITLE
Improve compatibility checker

### DIFF
--- a/Lib/fontmake/compatibility.py
+++ b/Lib/fontmake/compatibility.py
@@ -48,15 +48,15 @@ class CompatibilityChecker:
         )
         # Context for contextual anchors
         libs = [g.lib for g in glyphs]
-        for ix, anchors in enumerate(zip(*anchors)):
-            if anchors[0].name[0] == "*":
+        for each_anchors in zip(*anchors):
+            if each_anchors[0].name[0] == "*":
                 objectlibs = [
                     libs[font_ix]
                     .get("public.objectLibs", {})
                     .get(anchor.identifier, {})
-                    for font_ix, anchor in enumerate(anchors)
+                    for font_ix, anchor in enumerate(each_anchors)
                 ]
-                with Context(self, f"anchor {anchors[0].name}"):
+                with Context(self, f"anchor {each_anchors[0].name}"):
                     self.ensure_all_same(
                         lambda lib: lib.get("GPOS_Context", "None").strip(),
                         objectlibs,

--- a/Lib/fontmake/compatibility.py
+++ b/Lib/fontmake/compatibility.py
@@ -84,14 +84,17 @@ class CompatibilityChecker:
         if len(values) < 2:
             logger.debug(f"All fonts had same {what} in {context}")
             return True
-        logger.error(f"Fonts had differing {what} in {context}:")
+        report = f"\nFonts had differing {what} in {context}:\n"
         debug_enabled = logger.isEnabledFor(logging.DEBUG)
         for value, fonts in values.items():
             if debug_enabled or len(fonts) <= 6:
                 key = ", ".join(fonts)
             else:
                 key = f"{len(fonts)} fonts"
-            logger.error(f" * {key} had {value}")
+            if len(str(value)) > 20:
+                value = "\n    " + str(value)
+            report += f" * {key} had: {value}\n"
+        logger.error(report)
         self.okay = False
         return False
 

--- a/Lib/fontmake/compatibility.py
+++ b/Lib/fontmake/compatibility.py
@@ -46,6 +46,22 @@ class CompatibilityChecker:
             anchors,
             "anchors",
         )
+        # Context for contextual anchors
+        libs = [g.lib for g in glyphs]
+        for ix, anchors in enumerate(zip(*anchors)):
+            if anchors[0].name[0] == "*":
+                objectlibs = [
+                    libs[font_ix]
+                    .get("public.objectLibs", {})
+                    .get(anchor.identifier, {})
+                    for font_ix, anchor in enumerate(anchors)
+                ]
+                with Context(self, f"anchor {anchors[0].name}"):
+                    self.ensure_all_same(
+                        lambda lib: lib.get("GPOS_Context", "None").strip(),
+                        objectlibs,
+                        "GPOS context",
+                    )
 
         components = [g.components for g in glyphs]
         if self.ensure_all_same(len, components, "number of components"):

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -14,12 +14,12 @@ def test_compatibility_checker(data_dir, caplog):
 
     CompatibilityChecker([s.font for s in designspace.sources]).check()
     assert "differing number of contours in glyph A" in caplog.text
-    assert "Incompatible Sans Regular had 2" in caplog.text
+    assert "Incompatible Sans Regular had: 2" in caplog.text
 
     assert "differing number of points in glyph B, contour 0" in caplog.text
 
     assert "differing anchors in glyph A" in caplog.text
-    assert 'Incompatible Sans Bold had "foo"' in caplog.text
+    assert 'Incompatible Sans Bold had: "foo"' in caplog.text
 
     assert "Fonts had differing number of components in glyph C" in caplog.text
 


### PR DESCRIPTION
This PR:

* adds checking for the compatibility of GPOS contexts between contextual anchors (which can cause very confusing merge errors as entire lookups end up not aligning).
* improves the display of compatibility error messages

Before:

```
ERROR:fontmake.compatibility:Fonts had differing point type in glyph D, contour 0, point 9:
ERROR:fontmake.compatibility: * Incompatible Sans Regular had curve
ERROR:fontmake.compatibility: * Incompatible Sans Bold had line
ERROR:fontmake.compatibility:Fonts had differing point type in glyph D, contour 0, point 10:
ERROR:fontmake.compatibility: * Incompatible Sans Regular had None
ERROR:fontmake.compatibility: * Incompatible Sans Bold had line
ERROR:fontmake.compatibility:Fonts had differing point type in glyph D, contour 0, point 11:
ERROR:fontmake.compatibility: * Incompatible Sans Regular had None
ERROR:fontmake.compatibility: * Incompatible Sans Bold had line
```

After:

```
ERROR:fontmake.compatibility:
Fonts had differing point type in glyph D, contour 0, point 9:
 * Incompatible Sans Regular had: curve
 * Incompatible Sans Bold had: line

ERROR:fontmake.compatibility:
Fonts had differing point type in glyph D, contour 0, point 10:
 * Incompatible Sans Regular had: None
 * Incompatible Sans Bold had: line

ERROR:fontmake.compatibility:
Fonts had differing point type in glyph D, contour 0, point 11:
 * Incompatible Sans Regular had: None
 * Incompatible Sans Bold had: line
 ```