### PR TITLE
`CompatibilityChecker`: check all layers within designspace sources

### DIFF
--- a/Lib/fontmake/compatibility.py
+++ b/Lib/fontmake/compatibility.py
@@ -100,15 +100,15 @@ class CompatibilityChecker:
         for obj, (font, layer) in zip(objs, self.current_layers):
             values.setdefault(func(obj), []).append(self._name_for(font, layer))
         if len(values) < 2:
-            logger.debug(f"All fonts had same {what} in {context}")
+            logger.debug(f"All sources had same {what} in {context}")
             return True
-        report = f"\nFonts had differing {what} in {context}:\n"
+        report = f"\nSources had differing {what} in {context}:\n"
         debug_enabled = logger.isEnabledFor(logging.DEBUG)
         for value, source_names in values.items():
             if debug_enabled or len(source_names) <= 6:
                 key = ", ".join(source_names)
             else:
-                key = f"{len(source_names)} fonts"
+                key = f"{len(source_names)} sources"
             if len(str(value)) > 20:
                 value = "\n    " + str(value)
             report += f" * {key} had: {value}\n"

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -1158,7 +1158,7 @@ class FontProject:
                 f"expected path or DesignSpaceDocument, found {type(designspace.__name__)}"
             )
 
-        logger.info("Loading %s DesignSpace source UFOs", len(designspace.sources))
+        logger.info("Loading %s DesignSpace sources", len(designspace.sources))
         designspace.loadSourceFonts(opener=self.open_ufo)
 
         # if no --feature-writers option was passed, check in the designspace's

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -21,10 +21,10 @@ def test_compatibility_checker(data_dir, caplog):
     assert "differing anchors in glyph A" in caplog.text
     assert 'Incompatible Sans Bold had: "foo"' in caplog.text
 
-    assert "Fonts had differing number of components in glyph C" in caplog.text
+    assert "Sources had differing number of components in glyph C" in caplog.text
 
     assert (
-        "Fonts had differing point type in glyph D, contour 0, point 10" in caplog.text
+        "Sources had differing point type in glyph D, contour 0, point 10" in caplog.text
     )
 
 


### PR DESCRIPTION
The problem is that the compatibility checker iterates over every source but does not consider whether they are sparse layers

This means that it duplicates work and misrepresents how many sources it's checking (given that it counts every layer, but only checks the default layer for each UFO)

This PR changes the reporting to be accurate (and improves phrasing / word choice to aid understanding), and **extends the `CompatibilityChecker`'s scope to include the previously unchecked non-default layers**

There's definitely cases where more checking is more betterer, however it'll creating additional compatibility check failures (even in the test data used within this repository). Before continuing this PR with tests etc., we want to make sure that the checks aren't now overstepping from correctness into things that should be warnings (e.g. are mismatching anchors in sparse layers worth failing the build over?). We'll add & update tests once we've discussed & decided

Aside: https://matklad.github.io/2022/10/24/actions-permissions.html