### PR TITLE
Designspace.lib["skipExportGlyphs"] must override invididual UFO's lib.plist when building statics

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -552,6 +552,7 @@ class FontProject:
         fea_include_dir=None,
         auto_use_my_metrics=True,
         drop_implied_oncurves=False,
+        skip_export_glyphs=None,
     ):
         """Build OpenType binaries from UFOs.
 
@@ -672,6 +673,7 @@ class FontProject:
             filters=filters,
             autoUseMyMetrics=auto_use_my_metrics,
             dropImpliedOnCurves=drop_implied_oncurves,
+            skipExportGlyphs=skip_export_glyphs,
             inplace=True,  # avoid extra copy
         )
 
@@ -1242,6 +1244,11 @@ class FontProject:
         output_dir=None,
         **kwargs,
     ):
+        # The skipExportGlyphs list is supposed to be taken from the Designspace
+        # when this is used as the starting point of the compilation process,
+        # overriding any skipExportGlyphs key in each UFO's lib.plist.
+        # https://fonttools.readthedocs.io/en/latest/designspaceLib/index.html#public-skipexportglyphs
+        skip_export_glyphs = designspace.lib.get("public.skipExportGlyphs", [])
         save_ufos = "ufo" in outputs
         ufos = []
         if not interpolate or masters_as_instances:
@@ -1293,6 +1300,7 @@ class FontProject:
             fea_include_dir=fea_include_dir,
             output_path=output_path,
             output_dir=output_dir,
+            skip_export_glyphs=skip_export_glyphs,
             **kwargs,
         )
 


### PR DESCRIPTION
https://fonttools.readthedocs.io/en/latest/designspaceLib/index.html#public-skipexportglyphs

> applications using a Designspace as the corner stone of the font compilation process should use the lib key in that Designspace instead of any of the UFOs. If the lib key is empty or not present in the Designspace, all glyphs should be exported, regardless of what the same lib key in any of the UFOs says.

ufo2ft already does the right thing when fontmake gives it a designspace to build a VF, or when fontmake calls ufo2ft.instantiator to interpolate static UFOs.

However, when fontmake builds static master TTFs from a designspace input (i.e. `-o ttf -m Font.designspace` but _without_ the `-i` interpolate flag to build instances), then it simply loads the master UFOs as individual sources and calls compileTTF/compileOTF on each UFO. ufo2ft then reads the "public.skipExportGlyphs" in each individual UFO lib.plist, which should not have happened because fontmake started compiling from a designspace (but ufo2ft can't know that).

This PR fixes it, by reading the skipExportGlyphs key inside the designspace.lib (can be missing or empty) and passing it as parameter to ufo2ft compileTTF/compileOTF methods (this overrides whatever skipExportGlyphs in the UFO lib.plist).

The bug was spotted in https://github.com/googlefonts/fontc/issues/1507

It is a minor bug and we may actually prefer to close as wontfix. There may be old projects out there relying on the fact that `fontmake -m Font.designspace -o ttf` is a shorthand for a bunch of `fontmake -u Font-{Light,Regular,Bold}.ufo -o ttf` etc.