### PR TITLE
[compatibility cheker] Allow empty non-default glyphs

### DIFF
--- a/Lib/fontmake/errors.py
+++ b/Lib/fontmake/errors.py
@@ -21,6 +21,7 @@ class FontmakeError(Exception):
     """
 
     def __init__(self, msg, source_file):
+        super().__init__(msg, source_file)
         self.msg = msg
         self.source_trail = [source_file]
 
@@ -45,5 +46,5 @@ class FontmakeError(Exception):
 class TTFAError(FontmakeError):
     def __init__(self, exitcode, source_file):
         self.exitcode = exitcode
-        self.msg = f"ttfautohint failed with error code {str(self.exitcode)}"
-        self.source_trail = [source_file]
+        msg = f"ttfautohint failed with error code {str(exitcode)}"
+        super().__init__(msg, source_file)

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -1178,16 +1178,19 @@ class FontProject:
         # axes (that do not interpolate) and thus only some sub-spaces are
         # actually compatible for interpolation.
         for discrete_location, subDoc in splitInterpolable(designspace):
+            default_source = subDoc.findDefault()
+            assert default_source is not None, "Default source not found!"
+            default_source_idx = subDoc.sources.index(default_source)
+            source_fonts = [source.font for source in subDoc.sources]
             # glyphsLib currently stores this custom parameter on the fonts,
             # not the designspace, so we check if it exists in any font's lib.
-            source_fonts = [source.font for source in subDoc.sources]
             explicit_check = any(
                 font.lib.get(COMPAT_CHECK_KEY, False) for font in source_fonts
             )
             if check_compatibility is not False and (
                 interp_outputs or check_compatibility or explicit_check
             ):
-                if not CompatibilityChecker(source_fonts).check():
+                if not CompatibilityChecker(source_fonts, default_source_idx).check():
                     message = "Compatibility check failed"
                     if discrete_location:
                         message += f" in interpolable sub-space at {discrete_location}"

--- a/tests/data/IncompatibleSans/IncompatibleSans-Bold.ufo/glyphs/E_.glif
+++ b/tests/data/IncompatibleSans/IncompatibleSans-Bold.ufo/glyphs/E_.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="E" format="2">
+  <advance width="600"/>
+  <unicode hex="0045"/>
+  <outline>
+  </outline>
+</glyph>

--- a/tests/data/IncompatibleSans/IncompatibleSans-Bold.ufo/glyphs/contents.plist
+++ b/tests/data/IncompatibleSans/IncompatibleSans-Bold.ufo/glyphs/contents.plist
@@ -10,6 +10,8 @@
     <string>C_.glif</string>
     <key>D</key>
     <string>D_.glif</string>
+    <key>E</key>
+    <string>E_.glif</string>
     <key>space</key>
     <string>space.glif</string>
   </dict>

--- a/tests/data/IncompatibleSans/IncompatibleSans-Regular.ufo/glyphs/E_.glif
+++ b/tests/data/IncompatibleSans/IncompatibleSans-Regular.ufo/glyphs/E_.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<glyph name="space" format="2">
+<glyph name="E" format="2">
   <advance width="600"/>
-  <unicode hex="0020"/>
+  <unicode hex="0045"/>
   <outline>
     <contour>
-      <point x="0" y="0" type="line"/>
+      <point x="1" y="1" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/tests/data/IncompatibleSans/IncompatibleSans-Regular.ufo/glyphs/contents.plist
+++ b/tests/data/IncompatibleSans/IncompatibleSans-Regular.ufo/glyphs/contents.plist
@@ -10,6 +10,8 @@
     <string>C_.glif</string>
     <key>D</key>
     <string>D_.glif</string>
+    <key>E</key>
+    <string>E_.glif</string>
     <key>space</key>
     <string>space.glif</string>
   </dict>

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -27,6 +27,9 @@ def test_compatibility_checker(data_dir, caplog):
         "Fonts had differing point type in glyph D, contour 0, point 10" in caplog.text
     )
 
+    assert "differing number of contours in glyph space" in caplog.text
+    assert "differing number of contours in glyph E" not in caplog.text
+
 
 def test_compatibility_cli(data_dir, caplog):
     ds = str(data_dir / "IncompatibleSans" / "IncompatibleSans.designspace")


### PR DESCRIPTION


fonttools varLib already treats empty glyphs in non-default masters as non-participating ('sparse') in gvar interpolation. 
But fontmake's compatibility checker currently rejects these as it expects all glyphs to have the same number/type of segments.

In https://github.com/fonttools/fonttools/pull/3956 we relaxed this requirement in cu2qu. So we can now let fontmake pass these through.

Adding empty non-default glyhps can be useful for defining masters that only contribute kerning data. The kerning.plist needs the glyphs to be present in the UFO default layer, otherwise the the pair referencing any missing glyphs will be pruned by the ufo2ft kernFeatureWriter. By adding empty glyphs, the kerning pairs can stay and the ufo2ft's VariableKernFeatureWriter can generate a variable kern feature, but no additional gvar deltas will get added for those glyphs.

Fixes https://github.com/googlefonts/fontmake/issues/1158

