### PR TITLE
Generate preliminary openTypeCategories from GlyphData.xml for DS/UFOs

### DIFF
--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -114,6 +114,92 @@ class CurveConversion(enum.Enum):
         )
 
 
+OPENTYPE_CATEGORIES_KEY = PUBLIC_PREFIX + "openTypeCategories"
+
+try:
+    from dataclasses import fields as _dc_fields
+
+    from ufo2ft._compilers.baseCompiler import BaseCompiler as _BC
+
+    _HAS_PRELIMINARY_CATEGORIES = any(
+        f.name == "preliminaryOpenTypeCategories" for f in _dc_fields(_BC)
+    )
+except Exception:
+    _HAS_PRELIMINARY_CATEGORIES = False
+
+
+def _preliminary_categories_for_font(font):
+    """Generate preliminary openTypeCategories from GlyphData.xml for a font.
+
+    Returns a dict {glyphName: "mark"|"ligature"} for glyphs that can be
+    classified from GlyphData.xml alone, or None if the font already has
+    explicit categories or if ufo2ft is too old to support them.
+    The dict is intended for ufo2ft's ``preliminaryOpenTypeCategories`` kwarg;
+    ufo2ft finalizes it after anchor propagation (pruning anchorless ligatures
+    and inferring bases).
+
+    The classification logic matches glyphsLib's
+    ``_build_public_opentype_categories``:
+    https://github.com/googlefonts/glyphsLib/blob/75c07d42/Lib/glyphsLib/builder/features.py#L213-L272
+    """
+    from glyphsLib import glyphdata
+
+    if not _HAS_PRELIMINARY_CATEGORIES:
+        return None
+
+    if OPENTYPE_CATEGORIES_KEY in font.lib:
+        return None
+
+    categories = {}
+    for glyph in font:
+        if glyph.name is None:
+            continue
+        glyphinfo = glyphdata.get_glyph(
+            glyph.name, unicodes=[f"{c:04X}" for c in glyph.unicodes]
+        )
+        category = (
+            glyph.lib.get(GLYPHS_PREFIX + "Glyphs.category") or glyphinfo.category
+        )
+        subCategory = (
+            glyph.lib.get(GLYPHS_PREFIX + "Glyphs.subCategory") or glyphinfo.subCategory
+        )
+        if category == "Mark" and subCategory in ("Nonspacing", "Spacing Combining"):
+            categories[glyph.name] = "mark"
+        elif subCategory == "Ligature":
+            categories[glyph.name] = "ligature"
+
+    if not categories:
+        return None
+    logger.info(
+        "Generated preliminary openTypeCategories from GlyphData.xml: "
+        "%d mark, %d ligature",
+        sum(1 for v in categories.values() if v == "mark"),
+        sum(1 for v in categories.values() if v == "ligature"),
+    )
+    return categories
+
+
+def _generate_preliminary_categories(designspace):
+    """Generate preliminary openTypeCategories for a designspace.
+
+    ufo2ft's anchor propagation and GDEF generation rely on
+    public.openTypeCategories to classify glyphs as marks and ligatures.
+    DS+UFO sources authored outside Glyphs.app may not have them, so we
+    generate them from GlyphData.xml when they're absent.
+
+    Returns None if the designspace or its default source already has
+    explicit categories.
+    """
+    if OPENTYPE_CATEGORIES_KEY in designspace.lib:
+        return None
+
+    default_source = designspace.findDefault()
+    if default_source is None or default_source.font is None:
+        return None
+
+    return _preliminary_categories_for_font(default_source.font)
+
+
 def needs_subsetting(ufo):
     if KEEP_GLYPHS_OLD_KEY in ufo.lib or KEEP_GLYPHS_NEW_KEY in ufo.lib:
         return True
@@ -335,6 +421,11 @@ class FontProject:
         auto_use_my_metrics=False,
         **kwargs,
     ):
+        preliminary_categories = _generate_preliminary_categories(designspace)
+        extra = {}
+        if preliminary_categories:
+            extra["preliminaryOpenTypeCategories"] = preliminary_categories
+
         if ttf:
             ttf_curves = CurveConversion(ttf_curves)
             return ufo2ft.compileInterpolatableTTFsFromDS(
@@ -351,6 +442,7 @@ class FontProject:
                 flattenComponents=flatten_components,
                 autoUseMyMetrics=auto_use_my_metrics,
                 inplace=True,
+                **extra,
             )
         else:
             return ufo2ft.compileInterpolatableOTFsFromDS(
@@ -362,6 +454,7 @@ class FontProject:
                 feaIncludeDir=fea_include_dir,
                 filters=filters,
                 inplace=True,
+                **extra,
             )
 
     def build_interpolatable_ttfs(self, designspace, **kwargs):
@@ -445,6 +538,11 @@ class FontProject:
             "Building variable fonts " + ", ".join(vf_name_to_output_path.values())
         )
 
+        preliminary_categories = _generate_preliminary_categories(designspace)
+        extra = {}
+        if preliminary_categories:
+            extra["preliminaryOpenTypeCategories"] = preliminary_categories
+
         if ttf:
             ttf_curves = CurveConversion(ttf_curves)
             fonts = ufo2ft.compileVariableTTFs(
@@ -465,6 +563,7 @@ class FontProject:
                 autoUseMyMetrics=auto_use_my_metrics,
                 dropImpliedOnCurves=drop_implied_oncurves,
                 variableFeatures=variable_features,
+                **extra,
             )
         else:
             fonts = ufo2ft.compileVariableCFF2s(
@@ -479,6 +578,7 @@ class FontProject:
                 inplace=True,
                 variableFontNames=list(vf_name_to_output_path),
                 variableFeatures=variable_features,
+                **extra,
             )
 
         for name, font in fonts.items():
@@ -511,6 +611,10 @@ class FontProject:
         for ufo in ufos:
             name = self._font_name(ufo)
             logger.info(f"Building {fmt} for {name}")
+
+            preliminary = _preliminary_categories_for_font(ufo)
+            if preliminary:
+                options["preliminaryOpenTypeCategories"] = preliminary
 
             if debugFeatureFile and writeFontName:
                 debugFeatureFile.write(f"\n### {name} ###\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fonttools[ufo,repacker,lxml,unicode]==4.63.0; platform_python_implementation == 'CPython'
 fonttools[ufo,repacker,unicode]==4.63.0; platform_python_implementation != 'CPython'
 glyphsLib==6.11.6
-ufo2ft==3.6.1
+ufo2ft==3.8.0
 fontMath==0.9.4
 booleanOperations==0.9.0
 ufoLib2==0.18.1

--- a/tests/test_generate_preliminary_categories.py
+++ b/tests/test_generate_preliminary_categories.py
@@ -1,0 +1,209 @@
+"""Unit tests for fontmake.font_project._generate_preliminary_categories.
+
+All tests are in-memory (no disk I/O) and exercise the helper function
+directly, covering every early-exit guard and classification path.
+"""
+
+import ufoLib2
+from fontTools import designspaceLib
+
+from fontmake.font_project import (
+    GLYPHS_PREFIX,
+    OPENTYPE_CATEGORIES_KEY,
+    _generate_preliminary_categories,
+)
+
+
+def make_designspace(font=None):
+    """Return a minimal DesignSpaceDocument whose default source has *font*.
+
+    A single source with no location is used so that ``findDefault()``
+    returns it unambiguously.
+    """
+    ds = designspaceLib.DesignSpaceDocument()
+    source = designspaceLib.SourceDescriptor()
+    source.font = font if font is not None else ufoLib2.Font()
+    ds.sources.append(source)
+    return ds
+
+
+class TestEarlyExits:
+    def test_returns_none_when_categories_in_designspace_lib(self):
+        """Skip generation when the designspace already has explicit categories."""
+        ds = make_designspace()
+        ds.lib[OPENTYPE_CATEGORIES_KEY] = {"A": "base"}
+        assert _generate_preliminary_categories(ds) is None
+
+    def test_returns_none_when_no_sources(self):
+        """Skip when there is no default source at all."""
+        ds = designspaceLib.DesignSpaceDocument()
+        assert _generate_preliminary_categories(ds) is None
+
+    def test_returns_none_when_default_source_has_no_font(self):
+        """Skip when the default source exists but its font is not loaded."""
+        ds = designspaceLib.DesignSpaceDocument()
+        source = designspaceLib.SourceDescriptor()
+        # source.font is None by default
+        ds.sources.append(source)
+        assert _generate_preliminary_categories(ds) is None
+
+    def test_returns_none_when_categories_in_font_lib(self):
+        """Skip generation when the default source UFO already has explicit categories."""
+        font = ufoLib2.Font()
+        font.lib[OPENTYPE_CATEGORIES_KEY] = {"acutecomb": "mark"}
+        ds = make_designspace(font)
+        assert _generate_preliminary_categories(ds) is None
+
+    def test_returns_none_when_no_classifiable_glyphs(self):
+        """Return None (not an empty dict) when no glyphs yield a category."""
+        font = ufoLib2.Font()
+        # 'space' is Separator/Space — not a mark or ligature
+        font.newGlyph("space").unicodes = [0x0020]
+        # 'A' is Letter/None — not classified
+        font.newGlyph("A").unicodes = [0x0041]
+        ds = make_designspace(font)
+        assert _generate_preliminary_categories(ds) is None
+
+
+class TestGlyphDataClassification:
+    def test_nonspacing_mark_via_glyphdata(self):
+        """Glyphs GlyphData knows as Mark/Nonspacing are classified as 'mark'."""
+        font = ufoLib2.Font()
+        font.newGlyph("acutecomb").unicodes = [0x0301]
+        font.newGlyph("gravecomb").unicodes = [0x0300]
+        ds = make_designspace(font)
+        result = _generate_preliminary_categories(ds)
+        assert result is not None
+        assert result["acutecomb"] == "mark"
+        assert result["gravecomb"] == "mark"
+
+    def test_ligature_via_glyphdata(self):
+        """Glyphs GlyphData knows as */Ligature are classified as 'ligature'."""
+        font = ufoLib2.Font()
+        font.newGlyph("f_i")
+        font.newGlyph("f_l")
+        ds = make_designspace(font)
+        result = _generate_preliminary_categories(ds)
+        assert result is not None
+        assert result["f_i"] == "ligature"
+        assert result["f_l"] == "ligature"
+
+    def test_unclassifiable_glyphs_are_absent_from_result(self):
+        """Glyphs that are neither mark nor ligature must not appear in the result."""
+        font = ufoLib2.Font()
+        font.newGlyph("acutecomb").unicodes = [0x0301]  # mark
+        font.newGlyph("A").unicodes = [0x0041]  # letter — not classified
+        ds = make_designspace(font)
+        result = _generate_preliminary_categories(ds)
+        assert result is not None
+        assert "A" not in result
+
+    def test_marks_and_ligatures_coexist(self):
+        """Both marks and ligatures can appear together in one result dict."""
+        font = ufoLib2.Font()
+        font.newGlyph("acutecomb").unicodes = [0x0301]
+        font.newGlyph("f_i")
+        ds = make_designspace(font)
+        result = _generate_preliminary_categories(ds)
+        assert result is not None
+        assert result["acutecomb"] == "mark"
+        assert result["f_i"] == "ligature"
+
+
+class TestPerGlyphLibOverrides:
+    def test_mark_via_lib_override(self):
+        """A glyph classified as mark via its lib keys is returned as 'mark'."""
+        font = ufoLib2.Font()
+        g = font.newGlyph("customMark")
+        g.lib[GLYPHS_PREFIX + "Glyphs.category"] = "Mark"
+        g.lib[GLYPHS_PREFIX + "Glyphs.subCategory"] = "Nonspacing"
+        ds = make_designspace(font)
+        result = _generate_preliminary_categories(ds)
+        assert result is not None
+        assert result["customMark"] == "mark"
+
+    def test_spacing_combining_mark_via_lib_override(self):
+        """Mark/Spacing Combining in the lib keys is classified as 'mark'."""
+        font = ufoLib2.Font()
+        g = font.newGlyph("spacingMark")
+        g.lib[GLYPHS_PREFIX + "Glyphs.category"] = "Mark"
+        g.lib[GLYPHS_PREFIX + "Glyphs.subCategory"] = "Spacing Combining"
+        ds = make_designspace(font)
+        result = _generate_preliminary_categories(ds)
+        assert result is not None
+        assert result["spacingMark"] == "mark"
+
+    def test_ligature_via_lib_override(self):
+        """A glyph with subCategory=Ligature in its lib keys is classified as 'ligature'."""
+        font = ufoLib2.Font()
+        g = font.newGlyph("customLigature")
+        g.lib[GLYPHS_PREFIX + "Glyphs.subCategory"] = "Ligature"
+        ds = make_designspace(font)
+        result = _generate_preliminary_categories(ds)
+        assert result is not None
+        assert result["customLigature"] == "ligature"
+
+    def test_lib_override_beats_glyphdata_for_mark(self):
+        """Per-glyph lib keys take precedence over GlyphData when classifying marks."""
+        font = ufoLib2.Font()
+        # acutecomb is Mark/Nonspacing in GlyphData, but lib says it's a Letter
+        g = font.newGlyph("acutecomb")
+        g.unicodes = [0x0301]
+        g.lib[GLYPHS_PREFIX + "Glyphs.category"] = "Letter"
+        g.lib[GLYPHS_PREFIX + "Glyphs.subCategory"] = "Uppercase"
+        ds = make_designspace(font)
+        result = _generate_preliminary_categories(ds)
+        # lib override removes acutecomb from any classifiable category, so nothing remains
+        assert result is None
+
+    def test_lib_override_beats_glyphdata_for_ligature(self):
+        """Per-glyph lib keys take precedence over GlyphData when classifying ligatures."""
+        font = ufoLib2.Font()
+        # f_i is Letter/Ligature in GlyphData, but lib says it's a plain Letter
+        g = font.newGlyph("f_i")
+        g.lib[GLYPHS_PREFIX + "Glyphs.category"] = "Letter"
+        g.lib[GLYPHS_PREFIX + "Glyphs.subCategory"] = "Uppercase"
+        ds = make_designspace(font)
+        result = _generate_preliminary_categories(ds)
+        # lib override removes f_i from any classifiable category, so nothing remains
+        assert result is None
+
+    def test_partial_lib_override_falls_back_to_glyphdata(self):
+        """When only the category lib key is set, subCategory falls back to GlyphData."""
+        font = ufoLib2.Font()
+        # f_i is Letter/Ligature in GlyphData; override category to something else
+        # but leave subCategory unset so it falls through to GlyphData's "Ligature"
+        g = font.newGlyph("f_i")
+        g.lib[GLYPHS_PREFIX + "Glyphs.category"] = "Letter"  # same as GlyphData
+        # subCategory not set → GlyphData supplies "Ligature"
+        ds = make_designspace(font)
+        result = _generate_preliminary_categories(ds)
+        assert result is not None
+        assert result["f_i"] == "ligature"
+
+
+class TestLogging:
+    def test_info_logged_when_categories_generated(self, caplog):
+        """An INFO message must be emitted when preliminary categories are generated."""
+        import logging
+
+        font = ufoLib2.Font()
+        font.newGlyph("acutecomb").unicodes = [0x0301]
+        ds = make_designspace(font)
+        with caplog.at_level(logging.INFO, logger="fontmake.font_project"):
+            _generate_preliminary_categories(ds)
+        assert any(
+            "preliminary openTypeCategories" in r.message for r in caplog.records
+        )
+
+    def test_no_log_when_returning_none(self, caplog):
+        """No INFO message must be emitted when the function returns None early."""
+        import logging
+
+        ds = make_designspace()
+        ds.lib[OPENTYPE_CATEGORIES_KEY] = {"A": "base"}
+        with caplog.at_level(logging.INFO, logger="fontmake.font_project"):
+            _generate_preliminary_categories(ds)
+        assert not any(
+            "preliminary openTypeCategories" in r.message for r in caplog.records
+        )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,7 @@ from fontTools.ttLib.tables._g_l_y_f import USE_MY_METRICS
 from ufo2ft.util import zip_strict
 
 import fontmake.__main__
+from fontmake.font_project import OPENTYPE_CATEGORIES_KEY
 
 
 def test_interpolation(data_dir, tmp_path):
@@ -1688,3 +1689,184 @@ def test_auto_use_my_metrics_flag_for_single_ufo(
         has_use_my_metrics_flag(tmp_path / "WghtVarComposite-Regular.ttf", "equal")
         == auto_use_my_metrics
     )
+
+
+# GDEF GlyphClassDef values
+_BASE = 1
+_LIGATURE = 2
+_MARK = 3
+
+
+_PROPAGATE_ANCHORS_FILTER = {"name": "propagateAnchors"}
+
+
+def _make_test_font():
+    """Return a font with base, mark, ligature, and composite glyphs.
+
+    No public.openTypeCategories — preliminary categories must be generated
+    from GlyphData.xml for GDEF to be correct.  The PropagateAnchorsFilter
+    is enabled via the ufo2ft filters lib key.
+    """
+    font = ufoLib2.Font()
+    font.info.unitsPerEm = 1000
+    font.lib["com.github.googlei18n.ufo2ft.filters"] = [
+        _PROPAGATE_ANCHORS_FILTER,
+    ]
+
+    g = font.newGlyph(".notdef")
+    g.width = 500
+
+    g = font.newGlyph("space")
+    g.width = 250
+    g.unicodes = [0x0020]
+
+    g = font.newGlyph("a")
+    g.width = 350
+    g.unicodes = [0x0061]
+    pen = g.getPen()
+    pen.moveTo((0, 0))
+    pen.lineTo((300, 0))
+    pen.lineTo((300, 300))
+    pen.lineTo((0, 300))
+    pen.closePath()
+    g.appendAnchor(dict(name="top", x=150, y=300))
+    g.appendAnchor(dict(name="bottom", x=150, y=0))
+
+    g = font.newGlyph("acutecomb")
+    g.width = 0
+    g.unicodes = [0x0301]
+    pen = g.getPen()
+    pen.moveTo((0, 400))
+    pen.lineTo((100, 500))
+    pen.lineTo((0, 500))
+    pen.closePath()
+    g.appendAnchor(dict(name="_top", x=50, y=400))
+    g.appendAnchor(dict(name="top", x=50, y=550))
+
+    # Ligature: two 'a' components, no explicit anchors — should get
+    # top_1/top_2 etc. from anchor propagation
+    g = font.newGlyph("f_i")
+    g.width = 700
+    pen = g.getPen()
+    pen.addComponent("a", (1, 0, 0, 1, 0, 0))
+    pen.addComponent("a", (1, 0, 0, 1, 350, 0))
+
+    # Composite base — should be inferred as base from attaching anchors
+    g = font.newGlyph("aacute")
+    g.width = 350
+    g.unicodes = [0x00E1]
+    pen = g.getPen()
+    pen.addComponent("a", (1, 0, 0, 1, 0, 0))
+    pen.addComponent("acutecomb", (1, 0, 0, 1, 0, 0))
+
+    return font
+
+
+def _save_test_ufo(path, font=None):
+    """Save the test font as a UFO at *path*."""
+    if font is None:
+        font = _make_test_font()
+    font.save(str(path))
+
+
+def _save_test_designspace(tmp_path, ds_lib=None):
+    """Save a two-source designspace + UFOs under *tmp_path*.
+
+    Returns the path to the .designspace file.
+    """
+    light = _make_test_font()
+    bold = _make_test_font()
+
+    light_path = tmp_path / "TestLight.ufo"
+    bold_path = tmp_path / "TestBold.ufo"
+    light.save(str(light_path))
+    bold.save(str(bold_path))
+
+    ds = designspaceLib.DesignSpaceDocument()
+    ds.addAxisDescriptor(
+        name="weight", tag="wght", minimum=400, default=400, maximum=700
+    )
+    light_source = designspaceLib.SourceDescriptor()
+    light_source.filename = "TestLight.ufo"
+    light_source.location = {"weight": 400}
+    ds.sources.append(light_source)
+    bold_source = designspaceLib.SourceDescriptor()
+    bold_source.filename = "TestBold.ufo"
+    bold_source.location = {"weight": 700}
+    ds.sources.append(bold_source)
+    if ds_lib:
+        ds.lib.update(ds_lib)
+    ds_path = tmp_path / "Test.designspace"
+    ds.write(str(ds_path))
+    return ds_path
+
+
+def test_preliminary_categories_variable_gdef(tmp_path):
+    """Building a DS without explicit categories should produce correct
+    GDEF via preliminary categories from GlyphData.xml."""
+    ds_path = _save_test_designspace(tmp_path)
+    fontmake.__main__.main(
+        ["-m", str(ds_path), "-o", "variable", "--output-dir", str(tmp_path)]
+    )
+    ttfont = fontTools.ttLib.TTFont(tmp_path / "Test-VF.ttf")
+
+    assert "GDEF" in ttfont
+    classDefs = ttfont["GDEF"].table.GlyphClassDef.classDefs
+    assert classDefs["acutecomb"] == _MARK
+    assert classDefs["f_i"] == _LIGATURE
+    assert classDefs["a"] == _BASE
+    assert classDefs["aacute"] == _BASE
+
+
+def test_preliminary_categories_variable_explicit_precedence(tmp_path):
+    """When the DS lib has explicit categories, preliminary generation
+    is skipped and the explicit categories drive GDEF."""
+    ds_path = _save_test_designspace(
+        tmp_path,
+        ds_lib={OPENTYPE_CATEGORIES_KEY: {"acutecomb": "mark", "a": "base"}},
+    )
+    fontmake.__main__.main(
+        ["-m", str(ds_path), "-o", "variable", "--output-dir", str(tmp_path)]
+    )
+    ttfont = fontTools.ttLib.TTFont(tmp_path / "Test-VF.ttf")
+
+    assert "GDEF" in ttfont
+    classDefs = ttfont["GDEF"].table.GlyphClassDef.classDefs
+    assert classDefs["acutecomb"] == _MARK
+    assert classDefs.get("f_i") != _LIGATURE
+
+
+def test_preliminary_categories_static_gdef(tmp_path):
+    """Building a single UFO without explicit categories should produce
+    correct GDEF via preliminary categories from GlyphData.xml."""
+    ufo_path = tmp_path / "Test.ufo"
+    _save_test_ufo(ufo_path)
+    fontmake.__main__.main(
+        ["-u", str(ufo_path), "-o", "ttf", "--output-dir", str(tmp_path)]
+    )
+    ttfont = fontTools.ttLib.TTFont(tmp_path / "Test.ttf")
+
+    assert "GDEF" in ttfont
+    classDefs = ttfont["GDEF"].table.GlyphClassDef.classDefs
+    assert classDefs["acutecomb"] == _MARK
+    assert classDefs["f_i"] == _LIGATURE
+    assert classDefs["a"] == _BASE
+    assert classDefs["aacute"] == _BASE
+
+
+def test_preliminary_categories_static_explicit_precedence(tmp_path):
+    """When the font lib has explicit categories, preliminary generation
+    is skipped and the explicit categories drive GDEF."""
+    font = _make_test_font()
+    font.lib[OPENTYPE_CATEGORIES_KEY] = {"acutecomb": "mark", "a": "base"}
+    ufo_path = tmp_path / "Test.ufo"
+    _save_test_ufo(ufo_path, font=font)
+    fontmake.__main__.main(
+        ["-u", str(ufo_path), "-o", "ttf", "--output-dir", str(tmp_path)]
+    )
+    ttfont = fontTools.ttLib.TTFont(tmp_path / "Test.ttf")
+
+    assert "GDEF" in ttfont
+    classDefs = ttfont["GDEF"].table.GlyphClassDef.classDefs
+    assert classDefs["acutecomb"] == _MARK
+    assert classDefs.get("f_i") != _LIGATURE


### PR DESCRIPTION
When building DS+UFO sources that lack explicit `public.openTypeCategories`, fontmake now generates preliminary categories for marks and ligatures using glyphsLib's GlyphData.xml and passes them to ufo2ft via the new
`preliminaryOpenTypeCategories` kwarg from https://github.com/googlefonts/ufo2ft/pull/985.

ufo2ft finalizes them after anchor propagation, pruning anchorless ligatures and inferring bases from attaching anchors.

This closes the gap between .glyphs and DS+UFO sources: .glyphs sources get categories via glyphsLib's export, but DS+UFO sources authored directly had no way to get them automatically. Without categories, ufo2ft's anchor propagation would fall back to fallible heuristics, leading to incorrect ligature anchor numbering and GDEF differences vs fontc.

`_preliminary_categories_for_font(font)` iterates over all glyphs and classifies them using `glyphsLib.glyphdata.get_glyph()`, respecting per-glyph category/subCategory overrides from the glyph's lib (matching Glyphs.app behavior). Marks are glyphs with category "Mark" and subCategory "Nonspacing" or "Spacing Combining"; ligatures are glyphs with subCategory "Ligature".

The categories are "preliminary" because they're based on GlyphData.xml alone, before anchor propagation. ufo2ft refines them: marks are kept as-is, ligatures are kept only if they gained attaching anchors after propagation, and bases are inferred for remaining glyphs with attaching anchors. This classification logic matches glyphsLib's [`_build_public_opentype_categories`](https://github.com/googlefonts/glyphsLib/blob/75c07d42/Lib/glyphsLib/builder/features.py#L213-L272).

Sources that already have explicit `public.openTypeCategories` (in the DS lib or font lib) are left untouched.

Depends on googlefonts/ufo2ft#985