### PR TITLE
only resolve the default source when running the compatibility check

### DIFF
--- a/Lib/fontmake/compatibility.py
+++ b/Lib/fontmake/compatibility.py
@@ -1,5 +1,7 @@
 import logging
 
+from fontmake.errors import FontmakeError
+
 logger = logging.getLogger(__name__)
 
 
@@ -21,6 +23,9 @@ class CompatibilityChecker:
         self.context = []
         self.okay = True
         self.fonts = fonts
+        # Defaults to the first source for backwards compatibility. Callers pass
+        # None to signal the designspace has no source at the default location,
+        # which check() rejects when there are two or more sources to interpolate.
         self.default_source_idx = default_source_idx
 
     @staticmethod
@@ -30,6 +35,19 @@ class CompatibilityChecker:
         )
 
     def check(self):
+        if len(self.fonts) < 2:
+            # fewer than two sources: nothing to interpolate, nothing to check
+            return self.okay
+        if self.default_source_idx is None:
+            # With two or more interpolatable sources we need a default to check
+            # (and later interpolate) against. If the designspace has no source
+            # at the default location, fail now with a clear message instead of
+            # later in varLib. https://github.com/googlefonts/fontmake/issues/1166
+            raise FontmakeError(
+                "Can't check compatibility: no source found at the default "
+                "location of the designspace",
+                None,
+            )
         default = self.fonts[self.default_source_idx]
         skip_export_glyphs = set(default.lib.get("public.skipExportGlyphs", ()))
         for glyph in default.keys():

--- a/Lib/fontmake/font_project.py
+++ b/Lib/fontmake/font_project.py
@@ -1282,9 +1282,6 @@ class FontProject:
         # axes (that do not interpolate) and thus only some sub-spaces are
         # actually compatible for interpolation.
         for discrete_location, subDoc in splitInterpolable(designspace):
-            default_source = subDoc.findDefault()
-            assert default_source is not None, "Default source not found!"
-            default_source_idx = subDoc.sources.index(default_source)
             source_fonts = [source.font for source in subDoc.sources]
             # glyphsLib currently stores this custom parameter on the fonts,
             # not the designspace, so we check if it exists in any font's lib.
@@ -1294,6 +1291,16 @@ class FontProject:
             if check_compatibility is not False and (
                 interp_outputs or check_compatibility or explicit_check
             ):
+                # Only resolve the default source when we are actually going to
+                # check compatibility: a static-only build doesn't interpolate
+                # and must not require a default source.
+                # https://github.com/googlefonts/fontmake/issues/1166
+                default_source = subDoc.findDefault()
+                default_source_idx = (
+                    subDoc.sources.index(default_source)
+                    if default_source is not None
+                    else None
+                )
                 if not CompatibilityChecker(source_fonts, default_source_idx).check():
                     message = "Compatibility check failed"
                     if discrete_location:

--- a/tests/data/NoDefaultSource/NoDefaultSource.designspace
+++ b/tests/data/NoDefaultSource/NoDefaultSource.designspace
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <!-- Regression fixture for https://github.com/googlefonts/fontmake/issues/1166
+       A single-master source whose only master does not sit at the axis default
+       location: the Weight axis defaults to 400 but the lone source is at design
+       coordinate 700. So no source lies at the default and findDefault() returns
+       None (splitInterpolable also drops the out-of-range source, leaving an empty
+       sub-space). This is the shape glyphsLib produces for single-master Glyphs
+       sources whose master coordinate differs from the axis default.
+       A static (-o ttf) build must not crash with "Default source not found!". -->
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="400" default="400"/>
+  </axes>
+  <sources>
+    <source filename="../IncompatibleSans/IncompatibleSans-Regular.ufo" name="regular">
+      <location><dimension name="Weight" xvalue="700"/></location>
+    </source>
+  </sources>
+</designspace>

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -4,6 +4,7 @@ from fontTools import designspaceLib
 
 from fontmake.__main__ import main
 from fontmake.compatibility import CompatibilityChecker
+from fontmake.errors import FontmakeError
 
 
 def test_compatibility_checker(data_dir, caplog):
@@ -49,3 +50,40 @@ def test_compatibility_cli(data_dir, caplog):
 
     # Things got to the cu2qu level (i.e. compatibility checker did not run)
     assert "cu2qu.ufo" in caplog.text
+
+
+def test_compatibility_fewer_than_two_sources():
+    # a single (or zero) source has nothing to interpolate, so the checker must
+    # not blow up indexing a (possibly missing) default source.
+    # https://github.com/googlefonts/fontmake/issues/1166
+    assert CompatibilityChecker([], default_source_idx=None).check()
+    assert CompatibilityChecker([object()], default_source_idx=None).check()
+
+
+def test_compatibility_no_default_source_raises(data_dir):
+    # Two or more interpolatable sources with no default source is a hard error:
+    # the checker pre-empts the failure varLib would raise later, rather than
+    # silently comparing against an arbitrary source.
+    # https://github.com/googlefonts/fontmake/issues/1166
+    designspace = designspaceLib.DesignSpaceDocument.fromfile(
+        data_dir / "IncompatibleSans" / "IncompatibleSans.designspace"
+    )
+    designspace.loadSourceFonts(opener=ufoLib2.objects.Font.open)
+    fonts = [s.font for s in designspace.sources]
+    with pytest.raises(FontmakeError, match="no source found at the default"):
+        CompatibilityChecker(fonts, default_source_idx=None).check()
+
+
+def test_no_default_source_static_build(data_dir, tmp_path):
+    # The fixture's only source sits at Weight=700 while the axis default is 400,
+    # so DesignSpaceDocument.findDefault() returns None. A static build must not
+    # raise "Default source not found!".
+    # https://github.com/googlefonts/fontmake/issues/1166
+    ds = str(data_dir / "NoDefaultSource" / "NoDefaultSource.designspace")
+    main(["-o", "ttf", "-m", ds, "--output-dir", str(tmp_path)])
+    assert (tmp_path / "IncompatibleSans-Regular.ttf").exists()
+
+    # an explicit compatibility check on the single source is a no-op, not a crash
+    main(
+        ["--check-compatibility", "-o", "ttf", "-m", ds, "--output-dir", str(tmp_path)]
+    )


### PR DESCRIPTION
PR #1163 added a `findDefault()` lookup and an `assert default_source is not None` above the gate that decides whether the interpolation compatibility check runs, so they executed for every build, including static-only ones that do not interpolate.

Single-master Glyphs sources whose only master does not sit at the axis default location produce a designspace where findDefault() returns None. Building these with -o ttf succeeded in 3.11.0 but started failing in 3.11.1 with "Default source not found!"; this hit Train, Lalezar and ~50 other Google Fonts.

Move the default-source lookup inside the gate so a static-only build never needs one. Make `default_source_idx` optional in CompatibilityChecker: with fewer than two sources there is nothing to interpolate and nothing to check, and with two or more sources but no source at the default location raise a clear FontmakeError instead of asserting, pre-empting the failure varLib would raise later anyway.

Fixes #1166